### PR TITLE
Go back to previous hash in history before reloading the page after a critical error

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,6 +2,7 @@ import styles from '../styles/app'
 
 import React from 'react'
 import { connect } from 'react-redux'
+import { hashHistory } from 'react-router'
 import { translate } from '../lib/I18n'
 import classNames from 'classnames'
 
@@ -9,8 +10,11 @@ import Alerter from './Alerter'
 import Sidebar from './Sidebar'
 import Topbar from './Topbar'
 
+// Reload page when a critical error occurs. Also, go back to the previous
+// state, supposed stable.
 const reload = () => {
-  window.location.reload()
+  hashHistory.listen(() => { window.location.reload() })
+  hashHistory.goBack()
 }
 
 const App = ({ t, error, children }) => (

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
-import { Route, Redirect } from 'react-router'
+import { Route, Redirect, hashHistory } from 'react-router'
 
 import App from './App'
 import Folder from '../containers/Folder'
 const ComingSoon = () => (<p style='margin-left: 2em'>Coming soon!</p>)
 
 const AppRoute = (
-  <Route component={App}>
+  <Route component={App} history={hashHistory}>
     <Redirect from='/' to='files' />
     <Route path='files(/:file)' component={Folder} />
     <Route path='recent' component={ComingSoon} />


### PR DESCRIPTION
@goldoraf, this one is for you, I just want to be sure that my code is OK.

As requested by @jsilvestre, we need to go back in hash history before reloading the page, otherwise we will try to reload the folder that we are not able to load, it is not logical in an UI point a view and it could make the whole app crashing infinetly.

Thanks :)