### PR TITLE
[fix] Use base 10 for file size computing

### DIFF
--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -57,7 +57,7 @@ class File extends Component {
         <td>
           {isDir(attributes)
             ? '-'
-            : filesize(attributes.size)}
+            : filesize(attributes.size, {base: 10})}
         </td>
         <td>—</td>
       </tr>


### PR DESCRIPTION
Filesize use base 2 by default. Added option to use base 10.