### PR TITLE
Register your device within an in-app browser

### DIFF
--- a/mobile/src/actions/index.js
+++ b/mobile/src/actions/index.js
@@ -1,1 +1,68 @@
+import cozy, { LocalStorage } from 'cozy-client-js'
+
 export const SETUP = 'SETUP'
+export const SET_URL = 'SET_URL'
+
+export const setupServerUrl = (router, location) => {
+  return async (dispatch, getState) => {
+    let oauth
+    if (window.cordova && window.cordova.InAppBrowser) {
+      oauth = {
+        storage: new LocalStorage(),
+        clientParams: {
+          redirectURI: 'http://localhost',
+          softwareID: 'io.cozy.mobile.files',
+          clientName: 'Mobile Cozy Files',
+          scopes: ['io.cozy.files:GET']
+        },
+        onRegistered: (client, url) => {
+          if (window.cordova && window.cordova.InAppBrowser) {
+            const { InAppBrowser } = window.cordova
+            const target = '_blank'
+            const options = 'location=yes,hidden=no'
+            const inAppBrowser = InAppBrowser.open(url, target, options)
+
+            return new Promise((resolve) => {
+              inAppBrowser.addEventListener('loadstop', ({url}) => {
+                var accessCode = /\?access_code=(.+)$/.exec(url)
+                var state = /\?state=(.+)$/.exec(url)
+
+                if (accessCode || state) {
+                  resolve(url)
+                }
+              })
+            })
+            .then(
+              (url) => {
+                inAppBrowser.close()
+                return url
+              },
+              (err) => {
+                inAppBrowser.close()
+                throw err
+              }
+            )
+          }
+        }
+      }
+    }
+
+    cozy.init({
+      cozyURL: `http://${getState().mobile.serverUrl}`,
+      oauth: oauth
+    })
+
+    try {
+      const creds = await cozy.authorize()
+      console.log('creds', creds)
+      dispatch({ type: SETUP })
+      if (location.state && location.state.nextPathname) {
+        router.replace(location.state.nextPathname)
+      } else {
+        router.replace('/')
+      }
+    } catch (err) {
+      throw err
+    }
+  }
+}

--- a/mobile/src/containers/OnBoarding.jsx
+++ b/mobile/src/containers/OnBoarding.jsx
@@ -6,7 +6,7 @@ import { translate } from '../../../src/lib/I18n'
 import Wizard from '../components/Wizard'
 
 import styles from '../styles/onboarding'
-import { setupServerUrl, SET_URL } from '../actions'
+import { registerDevice, SET_URL } from '../actions'
 
 import logo from '../../res/icon.png'
 
@@ -25,7 +25,7 @@ export const SelectServer = ({selectServer, t, updateServerUrl, serverUrl}) =>
 const mapDispatchToProps = (dispatch, ownProps) => ({
   selectServer: () => {
     const { router, location } = ownProps
-    dispatch(setupServerUrl(router, location))
+    dispatch(registerDevice(router, location))
   },
   updateServerUrl: (e) => {
     const serverUrl = e.target.value

--- a/mobile/src/containers/OnBoarding.jsx
+++ b/mobile/src/containers/OnBoarding.jsx
@@ -6,16 +6,16 @@ import { translate } from '../../../src/lib/I18n'
 import Wizard from '../components/Wizard'
 
 import styles from '../styles/onboarding'
-import { SETUP } from '../actions'
+import { setupServerUrl, SET_URL } from '../actions'
 
 import logo from '../../res/icon.png'
 
-export const SelectServer = ({selectServer, t}) =>
+export const SelectServer = ({selectServer, t, updateServerUrl, serverUrl}) =>
 (
   <div className={classnames(styles['wizard'])}>
     <div className={classnames(styles['wizard-main'])}>
       <p>{t('mobile.wizard.selectServer.cozy_address')}</p>
-      <input type='text' placeholder={t('mobile.wizard.selectServer.cozy_address_placeholder')} />
+      <input type='text' placeholder={t('mobile.wizard.selectServer.cozy_address_placeholder')} onChange={updateServerUrl} value={serverUrl} />
       <p>{t('mobile.wizard.selectServer.description')}</p>
     </div>
     <button role='button' className={classnames('coz-btn coz-btn--regular', styles['wizard-button'])} onClick={selectServer}>{t('mobile.wizard.selectServer.button')}</button>
@@ -24,17 +24,21 @@ export const SelectServer = ({selectServer, t}) =>
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   selectServer: () => {
-    dispatch({ type: SETUP })
     const { router, location } = ownProps
-    if (location.state && location.state.nextPathname) {
-      router.replace(location.state.nextPathname)
-    } else {
-      router.replace('/')
-    }
+    dispatch(setupServerUrl(router, location))
+  },
+  updateServerUrl: (e) => {
+    const serverUrl = e.target.value
+    dispatch({ type: SET_URL, url: serverUrl })
   }
 })
 
-const ConnectedSelectServer = connect(null, mapDispatchToProps)(SelectServer)
+const mapStateToProps = (state) => {
+  return ({
+    serverUrl: state.mobile.serverUrl
+  })
+}
+const ConnectedSelectServer = connect(mapStateToProps, mapDispatchToProps)(SelectServer)
 
 export const Welcome = ({ nextStep, t }) =>
 (

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -9,18 +9,12 @@ import { createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import { Router, Route, hashHistory } from 'react-router'
-import cozy from 'cozy-client-js'
 import { I18n } from '../../src/lib/I18n'
 
 import filesApp from './reducers'
 import AppRoute from '../../src/components/AppRoute'
 
 import OnBoarding from './containers/OnBoarding'
-
-cozy.init({
-  cozyURL: 'http://cozy.local:8080/',
-  token: 'TODO'
-})
 
 const context = window.context
 const lang = (navigator && navigator.language) ? navigator.language.slice(0, 2) : 'en'

--- a/mobile/src/reducers/mobile.js
+++ b/mobile/src/reducers/mobile.js
@@ -8,7 +8,7 @@ const initialState = {
 export const mobile = (state = initialState, action) => {
   switch (action.type) {
     case SET_URL:
-      return Object.assign({}, state, { serverUrl: action.url })
+      return Object.assign({}, state, { serverUrl: `http://${action.url}` })
     case SETUP:
       return Object.assign({}, state, { isSetup: true })
   }

--- a/mobile/src/reducers/mobile.js
+++ b/mobile/src/reducers/mobile.js
@@ -1,13 +1,16 @@
-import { SETUP } from '../actions'
+import { SETUP, SET_URL } from '../actions'
 
 const initialState = {
-  isSetup: false
+  isSetup: false,
+  serverUrl: ''
 }
 
 export const mobile = (state = initialState, action) => {
   switch (action.type) {
+    case SET_URL:
+      return Object.assign({}, state, { serverUrl: action.url })
     case SETUP:
-      return { isSetup: true }
+      return Object.assign({}, state, { isSetup: true })
   }
   return state
 }

--- a/mobile/test/__snapshots__/onboarding.spec.js.snap
+++ b/mobile/test/__snapshots__/onboarding.spec.js.snap
@@ -22,8 +22,10 @@ exports[`Wizard Component should render different components 2`] = `
     className="wizard-main">
     <p />
     <input
+      onChange={undefined}
       placeholder={undefined}
-      type="text" />
+      type="text"
+      value={undefined} />
     <p />
   </div>
   <button

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-preset-env": "^1.0.2",
     "babel-preset-react": "^6.16.0",
     "babel-runtime": "^6.0.0",
+    "btoa": "^1.1.2",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,6 +987,10 @@ bser@^1.0.2:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
+
 buffer-from@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.1.tgz#57b18b1da0a19ec06f33837a5275a242351bd75e"


### PR DESCRIPTION
This PR aims to let the user register his device and share authorization.  
A form is shown and on submit it validates the user's passphrase.
A `Authorize application` screen is displayed, use must accept.
Then user is redirected to the app and can browse cozy files.

**TODO**

- [x] change the permissions for the correct one
- [x] see if anyone see another way to *redirect to the app* after authorization accepted
- [x] write something that works outside of cordova (for development purpose)
- [ ] ~add some test? Not sure it's applicable~ (it uses a cordova plugin, I don't know how to test it)
- [x] change redux action name
- [x] change `clientParams` information
- [x] use real server url from `state`