### PR TITLE
Fix breadcrump router behaviour

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -44,7 +44,11 @@ export const openFolder = (folderId = ROOT_DIR_ID, isInitialFetch = false, route
     if (isInitialFetch) {
       dispatch({ type: RECEIVE_FILES, folderId })
     } else if (router) {
-      router.push(`/files/${folderId}`)
+      if (folderId === ROOT_DIR_ID) {
+        router.push('/files')
+      } else {
+        router.push(`/files/${folderId}`)
+      }
     }
     dispatch({
       type: OPEN_FOLDER_SUCCESS,

--- a/src/containers/Breadcrumb.jsx
+++ b/src/containers/Breadcrumb.jsx
@@ -60,5 +60,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   }
 })
 
-export default translate()(connect(
-  mapStateToProps, mapDispatchToProps)(withRouter(Breadcrumb)))
+export default translate()(withRouter(connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Breadcrumb)))


### PR DESCRIPTION
In the current breadcrumb, when you click on the root Files, the path doesn't change to the correct path means '/files'.
This PR fixes it.