### PR TITLE
fix tests with globals __ALLOW_HTTP__ and __TARGET__

### DIFF
--- a/mobile/src/actions/index.js
+++ b/mobile/src/actions/index.js
@@ -1,3 +1,5 @@
+/* global __ALLOW_HTTP__ */
+
 import cozy, { LocalStorage as Storage } from 'cozy-client-js'
 import localforage from 'localforage'
 
@@ -15,7 +17,6 @@ export class OnBoardingError extends Error {
 
 export function setUrl (url) {
   return async dispatch => {
-    let __ALLOW_HTTP__ = __ALLOW_HTTP__ || false
     let scheme = 'https://'
     if (__ALLOW_HTTP__) {
       scheme = 'http://'

--- a/package.json
+++ b/package.json
@@ -118,6 +118,10 @@
     "moduleNameMapper": {
       "\\.(png|gif|jpe?g|svg)$": "<rootDir>/test/__mocks__/fileMock.js",
       "styles": "identity-obj-proxy"
+    },
+    "globals": {
+      "__ALLOW_HTTP__": false,
+      "__TARGET__": "browser"
     }
   },
   "standard": {

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -37,7 +37,7 @@ const Nav = ({ t, router }) => {
             { t('nav.item_trash') }
           </Link>
         </li>
-        {__TARGET__ === '"mobile"' &&
+        {__TARGET__ === 'mobile' &&
         <li class={styles['fil-nav-item']}>
           <Link to='/settings' class={styles['fil-cat-settings']} activeClassName={styles['active']}>
             { t('nav.item_settings') }


### PR DESCRIPTION
jest do not use variables defined in webpack
so we have to add them in jest configuration

thanks @m4dz for pointing my little noise to this http://facebook.github.io/jest/docs/configuration.html#globals-object