### PR TITLE
Change error displayed when url is wrong

### DIFF
--- a/mobile/src/actions/index.js
+++ b/mobile/src/actions/index.js
@@ -10,9 +10,7 @@ export const ERROR = 'ERROR'
 
 const WRONG_ADDRESS = 'mobile.onboarding.server_selection.wrong_address'
 
-function error () {
-  return { type: ERROR, error: WRONG_ADDRESS }
-}
+const error = () => ({ type: ERROR, error: WRONG_ADDRESS })
 
 export class OnBoardingError extends Error {
   constructor (message) {
@@ -21,7 +19,7 @@ export class OnBoardingError extends Error {
   }
 }
 
-export function setUrl (url) {
+export const setUrl = (url) => {
   return async dispatch => {
     let scheme = 'https://'
     if (__ALLOW_HTTP__) {
@@ -39,6 +37,7 @@ export function setUrl (url) {
   }
 }
 
+// TODO need to refactor this braces hell
 export const registerDevice = (router, location) => {
   return async (dispatch, getState) => {
     await dispatch(setUrl(getState().mobile.serverUrl))

--- a/mobile/src/actions/index.js
+++ b/mobile/src/actions/index.js
@@ -8,6 +8,12 @@ export const SET_URL = 'SET_URL'
 export const SET_STATE = 'SET_STATE'
 export const ERROR = 'ERROR'
 
+const WRONG_ADDRESS = 'mobile.onboarding.server_selection.wrong_address'
+
+function error () {
+  return { type: ERROR, error: WRONG_ADDRESS }
+}
+
 export class OnBoardingError extends Error {
   constructor (message) {
     super(message)
@@ -23,7 +29,7 @@ export function setUrl (url) {
       console.warn('development mode: we don\'t check SSL requirement')
     }
     if (/(.*):\/\/(.*)/.test(url) && !url.startsWith(scheme)) {
-      dispatch({ type: ERROR, error: 'mobile.onboarding.server_selection.wrong_address' })
+      dispatch(error())
       throw new OnBoardingError(`The only supported protocol is ${scheme}`)
     }
     if (!url.startsWith(scheme)) {
@@ -71,7 +77,7 @@ export const registerDevice = (router, location) => {
               },
               (err) => {
                 inAppBrowser.close()
-                dispatch(error(err))
+                dispatch(error())
                 throw err
               }
             )
@@ -89,7 +95,7 @@ export const registerDevice = (router, location) => {
     try {
       await cozy.authorize()
     } catch (err) {
-      dispatch(error(err))
+      dispatch(error())
       throw err
     }
 
@@ -101,8 +107,4 @@ export const registerDevice = (router, location) => {
       router.replace('/')
     }
   }
-}
-
-function error (err) {
-  return { type: ERROR, error: err.message.toLowerCase().split(' ').join('_') }
 }


### PR DESCRIPTION
I use to keep the HTTP error received by cozy-client-js
but for user it may be clearer to have only one error:
"The address doesn't seem to match a Cozy."