### PR TITLE
[fix] FIL-16 : Prevent notifications when the aborting folder creation on purpose

### DIFF
--- a/src/components/File.jsx
+++ b/src/components/File.jsx
@@ -103,7 +103,7 @@ class File extends Component {
     if (editing) {
       return (
         <td className={classes}>
-          <FilenameInput name={attributes.name} error={attributes.creationError} onSubmit={val => this.edit(val)} onAbort={() => this.abortEdit()} />
+          <FilenameInput name={attributes.name} error={attributes.creationError} onSubmit={val => this.edit(val)} onAbort={accidental => this.abortEdit(accidental)} />
         </td>
       )
     }

--- a/src/components/FilenameInput.jsx
+++ b/src/components/FilenameInput.jsx
@@ -48,7 +48,7 @@ export default class FilenameInput extends Component {
     this.props.onSubmit(this.state.value)
   }
 
-  abort (accidental) {
+  abort (accidental = false) {
     this.props.onAbort(accidental)
   }
 

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -260,10 +260,10 @@ const alert = (state = null, action) => {
         type: 'info'
       }
     case ABORT_ADD_FOLDER:
-      return {
+      return action.accidental ? {
         message: 'alert.folder_abort',
         type: 'info'
-      }
+      } : state
     case CREATE_FOLDER_FAILURE_DUPLICATE:
       return {
         message: 'alert.folder_name',


### PR DESCRIPTION
When a user aborts a folder creation with escape, no notification should be shown.