### PR TITLE
fix: spread op for reducers and beyond

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,6 @@
       "useBuiltIns": true
     }],
     "react"
-  ]
+  ],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/mobile/src/reducers/index.js
+++ b/mobile/src/reducers/index.js
@@ -1,14 +1,9 @@
 import {combineReducers} from 'redux'
 
-import {folder, files} from '../../../src/reducers/folder'
-import ui from '../../../src/reducers/ui'
+import filesApp from '../../../src/reducers'
 import { mobile } from './mobile'
 
-const filesApp = combineReducers({
-  folder,
-  files,
-  ui,
+export default combineReducers({
+  ...filesApp,
   mobile
 })
-
-export default filesApp

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-core": "^6.0.0",
     "babel-jest": "^18.0.0",
     "babel-loader": "^6.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.0.0",
     "babel-polyfill": "^6.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,6 +484,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.13.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -677,6 +681,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.22.0.tgz#1d419b55e68d2e4f64a5ff3373bd67d73c8e83bc"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.22.0:


### PR DESCRIPTION
We added the spread operator to import and combine the browser's reducers inside our mobile reducer.