### PR TITLE
[fix] Better file trashing

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -176,7 +176,8 @@ export const trashFile = (id) => {
     }
     dispatch({
       type: TRASH_FILE_SUCCESS,
-      file: extractFileAttributes(trashed)
+      file: extractFileAttributes(trashed),
+      id
     })
   }
 }

--- a/src/reducers/folder.js
+++ b/src/reducers/folder.js
@@ -28,13 +28,12 @@ export const files = (state = [], action) => {
         ...state,
         action.file
       ]
-    case TRASH_FILE_SUCCESS:
-      return state.map(file => file.id === action.file.id ? action.file : file)
     case ADD_FOLDER:
       return [
         action.folder,
         ...state
       ]
+    case TRASH_FILE_SUCCESS:
     case DELETE_FILE:
       return state.filter(f => f.id !== action.id)
     case RENAME_FOLDER:

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -22,7 +22,7 @@ const newFilesFirst = files => files.sort((a, b) => {
 })
 
 const getSortedFiles = allFiles => {
-  let folders = allFiles.filter(f => f.type === 'directory' && f.id !== TRASH_DIR_ID && f.dir_id !== TRASH_DIR_ID)
+  let folders = allFiles.filter(f => f.type === 'directory' && f.id !== TRASH_DIR_ID)
   let files = allFiles.filter(f => f.type !== 'directory')
   return newFilesFirst(sortFiles(folders)).concat(sortFiles(files))
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -23,7 +23,7 @@ const newFilesFirst = files => files.sort((a, b) => {
 
 const getSortedFiles = allFiles => {
   let folders = allFiles.filter(f => f.type === 'directory' && f.id !== TRASH_DIR_ID && f.dir_id !== TRASH_DIR_ID)
-  let files = allFiles.filter(f => f.type !== 'directory' && f.dir_id !== TRASH_DIR_ID)
+  let files = allFiles.filter(f => f.type !== 'directory')
   return newFilesFirst(sortFiles(folders)).concat(sortFiles(files))
 }
 


### PR DESCRIPTION
The way files were seemed to work but was actually flawed.

A trashed file was kept in the `files` collection in the state, but with their `dir_id` set to the trash folder. Then, all files who's `dir_id` were the trash folder were hidden via another reducer.

This leads to the `files` collection in the state to sometimes contain files that are *not* inside the currently displayed folder (this caused at least one bug). It also makes it impossible to display files inside the trash folder.

The new approach is a lot more straightforward: a trashed file is removed from the `files` state, period.