### PR TITLE
SET_CLIENT to store cozy-client-js's client object in state

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -66,7 +66,7 @@ export const registerDevice = () => async (dispatch, getState) => {
   }
   await init(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
   try {
-    await cozy.authorize().then(({ client, token }) => dispatch(setClient(client)))
+    await cozy.authorize().then(({ client }) => dispatch(setClient(client)))
     await cozy.offline.replicateFromCozy('io.cozy.files')
   } catch (err) {
     dispatch(wrongAddressError())
@@ -74,6 +74,4 @@ export const registerDevice = () => async (dispatch, getState) => {
   }
 }
 
-export const setClient = (client) => {
-  return { type: SET_CLIENT, client }
-}
+export const setClient = client => ({ type: SET_CLIENT, client })

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -8,6 +8,7 @@ export const SET_URL = 'SET_URL'
 export const BACKUP_IMAGES_DISABLE = 'BACKUP_IMAGES_DISABLE'
 export const BACKUP_IMAGES_ENABLE = 'BACKUP_IMAGES_ENABLE'
 export const ERROR = 'ERROR'
+export const SET_CLIENT = 'SET_CLIENT'
 
 // url
 
@@ -65,10 +66,14 @@ export const registerDevice = () => async (dispatch, getState) => {
   }
   await init(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
   try {
-    await cozy.authorize()
+    await cozy.authorize().then(({ client, token }) => dispatch(setClient(client)))
     await cozy.offline.replicateFromCozy('io.cozy.files')
   } catch (err) {
     dispatch(wrongAddressError())
     throw err
   }
+}
+
+export const setClient = (client) => {
+  return { type: SET_CLIENT, client }
 }

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -42,6 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const stateToBeSaved = {
         mobile: {
           settings: store.getState().mobile.settings,
+          client: store.getState().mobile.client,
           mediaBackup: {
             uploaded: store.getState().mobile.mediaBackup.uploaded
           }

--- a/mobile/src/reducers/settings.js
+++ b/mobile/src/reducers/settings.js
@@ -1,5 +1,5 @@
 import { INIT_STATE } from '../actions'
-import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE } from '../actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT } from '../actions/settings'
 
 export const initialState = {
   serverUrl: '',
@@ -19,6 +19,8 @@ export const settings = (state = initialState, action) => {
       return { ...state, error: action.error }
     case INIT_STATE:
       return initialState
+    case SET_CLIENT:
+      return { ...state, client: action.client }
     default:
       return state
   }

--- a/mobile/test/actions/settings.spec.js
+++ b/mobile/test/actions/settings.spec.js
@@ -1,5 +1,5 @@
 import { mockStore } from '../../../test/helpers'
-import { SET_URL, checkURL, OnBoardingError } from '../../src/actions/settings'
+import { SET_URL, checkURL, OnBoardingError, setClient, SET_CLIENT } from '../../src/actions/settings'
 
 describe('actions creators', () => {
   it('should accept https://localhost', () => {
@@ -30,5 +30,13 @@ describe('actions creators', () => {
       .then(() => {
         expect(store.getActions()).toEqual([{ type: SET_URL, url: 'https://localhost' }])
       })
+  })
+
+  it('should set the new client', () => {
+    const store = mockStore()
+
+    const client = { someParameter: 'Some Value' }
+    store.dispatch(setClient(client))
+    expect(store.getActions()).toEqual([{ type: SET_CLIENT, client }])
   })
 })

--- a/mobile/test/actions/settings.spec.js
+++ b/mobile/test/actions/settings.spec.js
@@ -32,11 +32,10 @@ describe('actions creators', () => {
       })
   })
 
-  it('should set the new client', () => {
-    const store = mockStore()
-
+  it('should create SET_CLIENT action', () => {
     const client = { someParameter: 'Some Value' }
-    store.dispatch(setClient(client))
-    expect(store.getActions()).toEqual([{ type: SET_CLIENT, client }])
+    const expectedAction = { type: SET_CLIENT, client }
+
+    expect(setClient(client)).toEqual(expectedAction)
   })
 })

--- a/mobile/test/reducers/settings.spec.js
+++ b/mobile/test/reducers/settings.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/settings'
 import { INIT_STATE } from '../../src/actions'
-import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE } from '../../src/actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT } from '../../src/actions/settings'
 
 describe('ui reducers', () => {
   it('should return the initial state', () => {
@@ -33,5 +33,10 @@ describe('ui reducers', () => {
   it('should handle INIT_STATE', () => {
     expect(reducer({serverUrl: 'serverUrl', backupImages: true, error: 'error'}, {type: INIT_STATE}))
     .toEqual(initialState)
+  })
+
+  it('should set a client into the state with "SET_CLIENT"', () => {
+    const client = { someParameter: 'Some Value' }
+    expect(reducer(undefined, { type: SET_CLIENT, client }).client).toEqual(client)
   })
 })


### PR DESCRIPTION
It will be useful to get `clientID`, `registrationAccesToken` or `accessToken` to use `cozy.auth.getClient()` or `cozy.auth.unregisterClient()`. And so on...