### PR TITLE
feature: add sentry to watch errors

### DIFF
--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -18,7 +18,8 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       __ALLOW_HTTP__: !production,
-      __TARGET__: JSON.stringify('mobile')
+      __TARGET__: JSON.stringify('mobile'),
+      __SENTRY_TOKEN__: JSON.stringify('29bd1255b6d544a1b65435a634c9ff67')
     })
   ]
 }

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,6 +1,7 @@
 /* global __ALLOW_HTTP__ */
 
 import cozy from 'cozy-client-js'
+import Raven from 'raven-js'
 import { init } from '../lib/cozy-helper'
 import { onRegistered } from '../lib/registration'
 
@@ -63,6 +64,8 @@ export const registerDevice = () => async (dispatch, getState) => {
     .catch(err => {
       console.warn(err)
       dispatch(wrongAddressError())
+      Raven.captureException(err)
+      throw err
     })
   }
   await init(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
@@ -70,7 +73,9 @@ export const registerDevice = () => async (dispatch, getState) => {
     await cozy.authorize().then(({ client }) => dispatch(setClient(client)))
     await cozy.offline.replicateFromCozy('io.cozy.files')
   } catch (err) {
+    console.warn(err)
     dispatch(wrongAddressError())
+    Raven.captureException(err)
     throw err
   }
 }

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -9,6 +9,7 @@ import { createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import { Router, Route, hashHistory } from 'react-router'
+import Raven from 'raven-js'
 
 import { I18n } from '../../src/lib/I18n'
 
@@ -21,6 +22,8 @@ import Settings from './containers/Settings'
 
 import { loadState, saveState } from './lib/localStorage'
 import { init } from './lib/cozy-helper'
+
+Raven.config('https://29bd1255b6d544a1b65435a634c9ff67@sentry.cozycloud.cc/2').install()
 
 const context = window.context
 const lang = (navigator && navigator.language) ? navigator.language.slice(0, 2) : 'en'

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -1,3 +1,5 @@
+/* global __SENTRY_TOKEN__ */
+
 import 'babel-polyfill'
 
 import '../../src/styles/main'
@@ -23,7 +25,7 @@ import Settings from './containers/Settings'
 import { loadState, saveState } from './lib/localStorage'
 import { init } from './lib/cozy-helper'
 
-Raven.config('https://29bd1255b6d544a1b65435a634c9ff67@sentry.cozycloud.cc/2').install()
+Raven.config(`https://${__SENTRY_TOKEN__}@sentry.cozycloud.cc/2`).install()
 
 const context = window.context
 const lang = (navigator && navigator.language) ? navigator.language.slice(0, 2) : 'en'

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "pouchdb-find": "^0.10.4",
     "preact": "^7.1.0",
     "preact-compat": "^3.9.0",
+    "raven-js": "^3.10.0",
     "react-bosonic": "^1.0.0-beta5",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,7 +3506,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.0, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -5109,6 +5109,12 @@ randomatic@^1.1.3:
 range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
+
+raven-js@^3.10.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.11.0.tgz#3e309a335fe3314d16b15514ad95d32e05b9ca9a"
+  dependencies:
+    json-stringify-safe "^5.0.1"
 
 rc@^1.0.3, rc@~1.1.6:
   version "1.1.6"


### PR DESCRIPTION
This new feature gives access to sentry online logger.
JavaScript uses Raven to connect to sentry.cozycloud.cc.

Sentry's Dashboard looks like that:

![screen shot 2017-02-20 at 18 07 16-fullpage](https://cloud.githubusercontent.com/assets/701648/23135255/25c99422-f798-11e6-92dc-df0ca80054c8.png)

In another development, we will add an option (activable via settings) to trigger or not the error's capture.
As Sentry takes data from customer (private data such as IP address, and less sensible data), we have to check twice if the user is ok to send data, and what data the application sends. And we need to make a declaration for the purpose of our collect.