### PR TITLE
update sentry integration

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,8 +1,8 @@
 /* global cozy, __ALLOW_HTTP__ */
 
-import Raven from 'raven-js'
 import { init } from '../lib/cozy-helper'
 import { onRegistered } from '../lib/registration'
+import { logException } from '../lib/crash-reporter'
 
 export const SET_URL = 'SET_URL'
 export const BACKUP_IMAGES_DISABLE = 'BACKUP_IMAGES_DISABLE'
@@ -61,9 +61,8 @@ export const registerDevice = () => async (dispatch, getState) => {
     return onRegistered(client, url)
     .then(url => url)
     .catch(err => {
-      console.warn(err)
       dispatch(wrongAddressError())
-      Raven.captureException(err)
+      logException(err)
       throw err
     })
   }
@@ -72,9 +71,8 @@ export const registerDevice = () => async (dispatch, getState) => {
     await cozy.client.authorize().then(({ client }) => dispatch(setClient(client)))
     await cozy.client.offline.replicateFromCozy('io.cozy.files')
   } catch (err) {
-    console.warn(err)
     dispatch(wrongAddressError())
-    Raven.captureException(err)
+    logException(err)
     throw err
   }
 }

--- a/mobile/src/lib/crash-reporter.js
+++ b/mobile/src/lib/crash-reporter.js
@@ -1,0 +1,15 @@
+/* global __SENTRY_TOKEN__ */
+import Raven from 'raven-js'
+
+export function logException (err, context) {
+  if (!Raven.isSetup()) {
+    Raven.config(`https://${__SENTRY_TOKEN__}@sentry.cozycloud.cc/2`).install()
+  }
+  Raven.captureException(err, {
+    extra: context
+  })
+  console.groupCollapsed('Raven is recording exception')
+  console.error(err)
+  console.info(context)
+  console.groupEnd()
+}

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -11,7 +11,7 @@ import { createStore, applyMiddleware } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import createLogger from 'redux-logger'
 import { Router, Route, hashHistory } from 'react-router'
-import Raven from 'raven-js'
+import RavenMiddleWare from 'redux-raven-middleware'
 
 import { I18n } from '../../src/lib/I18n'
 
@@ -40,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
       filesApp,
       persistedState,
       applyMiddleware(
+        RavenMiddleWare(`https://${__SENTRY_TOKEN__}@sentry.cozycloud.cc/2`),
         thunkMiddleware,
         loggerMiddleware
       )

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -25,8 +25,6 @@ import Settings from './containers/Settings'
 import { loadState, saveState } from './lib/localStorage'
 import { init } from './lib/cozy-helper'
 
-Raven.config(`https://${__SENTRY_TOKEN__}@sentry.cozycloud.cc/2`).install()
-
 const context = window.context
 const lang = (navigator && navigator.language) ? navigator.language.slice(0, 2) : 'en'
 

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",
     "redux-mock-store": "^1.2.1",
+    "redux-raven-middleware": "^1.2.0",
     "redux-thunk": "^2.1.0"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raven-js@^3.10.0:
+raven-js@^3.1.1, raven-js@^3.10.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.11.0.tgz#3e309a335fe3314d16b15514ad95d32e05b9ca9a"
   dependencies:
@@ -5354,6 +5354,12 @@ redux-logger@^2.7.4:
 redux-mock-store@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.2.tgz#38007dc38f12ca8d965c7521afee5ccacc234d03"
+
+redux-raven-middleware@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redux-raven-middleware/-/redux-raven-middleware-1.2.0.tgz#50d02dd653cf93d2df18c4652149f1009bbbe33d"
+  dependencies:
+    raven-js "^3.1.1"
 
 redux-thunk@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
It appears to be a good tips to add the current state if a dispatch throws an exception.

Cf. https://blog.sentry.io/2016/08/24/redux-middleware-error-logging.html

So these commits introduce two concepts:
- an automatic redux dispatch exception logger
- a helper `logException` to let developer add exception in Sentry