### PR TITLE
Update missing deps

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -39,6 +39,11 @@ module.exports = {
       /localforage\/dist/
     ]
   },
+  postcss: () => {
+    return [
+      require('autoprefixer')(['last 2 versions'])
+    ]
+  },
   plugins: [
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '../src/index.ejs'),

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "git-directory-deploy": "^1.5.0",
     "html-webpack-plugin": "^2.24.0",
     "identity-obj-proxy": "^3.0.0",
+    "imports-loader": "^0.7.0",
     "jest": "^18.0.0",
     "json-loader": "^0.5.0",
     "npm-run-all": "^3.1.0",
@@ -93,8 +94,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.0",
-    "cozy-bar": "^3.0.0-beta1",
-    "cozy-client-js": "^0.0.10",
+    "cozy-bar": "beta",
+    "cozy-client-js": "beta",
     "cozy-ui": "3.0.0-beta11",
     "date-fns": "^1.22.0",
     "filesize": "^3.3.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: [
-    require('autoprefixer')(['last 2 versions'])
-  ]
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,15 +1412,15 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
-cozy-bar@^3.0.0-beta1:
+cozy-bar@beta:
   version "3.0.0-beta7"
   resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-3.0.0-beta7.tgz#703bc2e7b08412c11cbe12e973ddaeda30d13a33"
   dependencies:
     node-polyglot "^2.2.2"
 
-cozy-client-js@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.0.10.tgz#afebf314e8502283b8144e5aa0be57ff825ae056"
+cozy-client-js@beta:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.1.0.tgz#c0a39b33dfc61e4fc7fea3fbb6d04ed14a2d9a85"
 
 cozy-ui@3.0.0-beta11:
   version "3.0.0-beta11"
@@ -2849,13 +2849,9 @@ hyperquest@~1.2.0:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@^0.4.5, iconv-lite@~0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 icss-replace-symbols@^1.0.2:
   version "1.0.2"
@@ -2882,6 +2878,13 @@ image-size@^0.3.5:
 immediate@3.0.6, immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+
+imports-loader@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.7.0.tgz#468c04de8075941cfab28146c755c24cc1f36ccd"
+  dependencies:
+    loader-utils "^0.2.16"
+    source-map "^0.5.6"
 
 imurmurhash@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Add missing dep for `imports-loader`, needed for stack assets dev mode (https://github.com/m4dz/cozy-files-v3/blob/update/deps/config/webpack.config.dev.js#L11) and update stack assets deps.