### PR TITLE
Upgrade cordova plugin image & fix permission :bug: on Android

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -55,7 +55,7 @@
     <plugin name="cordova-plugin-file" spec="4.3.1" />
     <plugin name="cordova-plugin-appinfo" spec="2.1.1" />
     <plugin name="cordova-plugin-file-opener2" spec="2.0.7" />
-    <plugin name="cordova-plugin-photo-library" spec="1.2.2">
+    <plugin name="cordova-plugin-photo-library" spec="2.0.3">
         <variable name="PHOTO_LIBRARY_USAGE_DESCRIPTION" value="This app requires access to the photo library." />
     </plugin>
 </widget>

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -1,6 +1,6 @@
 /* global cozy */
 
-import { getPhotos, getBlob } from '../lib/media'
+import { getFilteredPhotos, getBlob } from '../lib/media'
 import { HTTP_CODE_CONFLICT } from '../../../src/actions'
 
 export const MEDIA_UPLOAD_START = 'MEDIA_UPLOAD_START'
@@ -13,7 +13,7 @@ export const successImageUpload = (image) => ({ type: IMAGE_UPLOAD_SUCCESS, id: 
 
 export const mediaBackup = () => async (dispatch, getState) => {
   dispatch(startMediaUpload())
-  let photos = await getPhotos()
+  let photos = await getFilteredPhotos()
   const alreadyUploaded = getState().mobile.mediaBackup.uploaded
   for (let photo of photos) {
     if (!alreadyUploaded.includes(photo.id)) {

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -20,7 +20,7 @@ export const mediaBackup = () => async (dispatch, getState) => {
       const blob = await getBlob(photo)
       const options = {
         dirID: 'io.cozy.files.root-dir',
-        name: photo.filename
+        name: photo.fileName
       }
       await cozy.client.files.create(blob, options).then(() => {
         dispatch(successImageUpload(photo))

--- a/mobile/src/lib/media.js
+++ b/mobile/src/lib/media.js
@@ -67,3 +67,13 @@ export const getPhotos = async () => {
 
   return defaultReturn
 }
+
+export const getFilteredPhotos = async () => {
+  let photos = await getPhotos()
+
+  if (window.cordova.platformId === 'android') {
+    photos = photos.filter((photo) => photo.id.indexOf('DCIM') !== -1)
+  }
+
+  return Promise.resolve(photos)
+}

--- a/mobile/src/lib/media.js
+++ b/mobile/src/lib/media.js
@@ -12,6 +12,9 @@ export const requestAuthorization = async () => {
         (error) => {
           console.warn(error)
           resolve(false)
+        },
+        {
+          read: true
         }
       )
     })
@@ -39,8 +42,9 @@ export const getPhotos = async () => {
   if (hasCordovaPlugin()) {
     return new Promise((resolve, reject) => {
       window.cordova.plugins.photoLibrary.getLibrary(
-        (library) => resolve(library),
+        (response) => resolve(response.library),
         (err) => {
+          console.warn(err)
           if (err.startsWith('Permission')) {
             requestAuthorization().then(authorization => {
               if (authorization) {
@@ -48,6 +52,9 @@ export const getPhotos = async () => {
               } else {
                 resolve(defaultReturn)
               }
+            }).catch(err => {
+              console.warn(err)
+              resolve(defaultReturn)
             })
           } else {
             console.warn(err)


### PR DESCRIPTION
- [x] Upgrade plugin from 1.2.2 to 2.0.3
- [x] Add specific authorization to fix bug on Android ([doc](https://github.com/terikon/cordova-plugin-photo-library#permissions))
- [x] Add a filter on Android

To valide: On settings clic on 'Launch Backup' you can see an Android popup with authorization.