### PR TITLE
feat: manage device revocation

### DIFF
--- a/mobile/src/actions/authorization.js
+++ b/mobile/src/actions/authorization.js
@@ -1,0 +1,5 @@
+export const REVOKE = 'REVOKE'
+export const UNREVOKE = 'UNREVOKE'
+
+export const revokeClient = () => ({ type: REVOKE })
+export const unrevokeClient = () => ({ type: UNREVOKE })

--- a/mobile/src/containers/RevokableWrapper.jsx
+++ b/mobile/src/containers/RevokableWrapper.jsx
@@ -1,0 +1,58 @@
+/* global cozy */
+
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import Modal from 'cozy-ui/react/Modal'
+import { translate } from '../../../src/lib/I18n'
+import { resetClient } from '../lib/cozy-helper'
+import { unrevokeClient } from '../actions/authorization'
+import { registerDevice } from '../actions/settings'
+
+class RevokableWrapper extends Component {
+
+  logout () {
+    resetClient()
+    this.props.unrevokeClient()
+    this.props.router.replace({
+      pathname: '/onboarding',
+      state: { nextPathname: this.props.location.pathname }
+    })
+  }
+
+  loginagain () {
+    cozy.client._storage.clear()
+    this.props.registerDevice()
+  }
+
+  render () {
+    const { children, t } = this.props
+    if (this.props.revoked) {
+      return (
+        <div>
+          <Modal
+            title={t('mobile.revoked.title')}
+            description={t('mobile.revoked.description')}
+            cancelText={t('mobile.revoked.logout')}
+            cancelAction={() => { this.logout() }}
+            validateText={t('mobile.revoked.loginagain')}
+            validateAction={() => { this.loginagain() }}
+          />
+          {children}
+        </div>
+      )
+    } else {
+      return children
+    }
+  }
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  unrevokeClient: () => dispatch(unrevokeClient()),
+  registerDevice: () => dispatch(registerDevice()).then(() => { dispatch(unrevokeClient()) })
+})
+
+const mapStateToProps = (state) => ({
+  revoked: state.mobile.authorization.revoked
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate()(RevokableWrapper))

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -34,3 +34,14 @@ export const initBar = () => {
     lang: 'en'
   })
 }
+
+export const isClientRegistered = async (client) => {
+  return await cozy.client.auth.getClient(client).then(client => true).catch(() => false)
+}
+
+export function resetClient () {
+  // reset pouchDB
+  cozy.client.offline.destroyAllDatabase()
+  // reset cozy-client-js
+  cozy.client._storage.clear()
+}

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -36,7 +36,16 @@ export const initBar = () => {
 }
 
 export const isClientRegistered = async (client) => {
-  return await cozy.client.auth.getClient(client).then(client => true).catch(() => false)
+  return await cozy.client.auth.getClient(client).then(client => true).catch(err => {
+    if (err.message === 'Client has been revoked') {
+      return false
+    }
+    // this is the error sent if we are offline
+    if (err.message === 'Failed to fetch') {
+      return true
+    }
+    throw err
+  })
 }
 
 export function resetClient () {

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -40,6 +40,8 @@ export const isClientRegistered = async (client) => {
 }
 
 export function resetClient () {
+  // reset cozy-bar
+  // TODO
   // reset pouchDB
   cozy.client.offline.destroyAllDatabase()
   // reset cozy-client-js

--- a/mobile/src/reducers/authorization.js
+++ b/mobile/src/reducers/authorization.js
@@ -1,0 +1,15 @@
+import { REVOKE, UNREVOKE } from '../actions/authorization'
+
+export const initialState = {
+}
+
+export const authorization = (state = initialState, action) => {
+  switch (action.type) {
+    case REVOKE:
+      return { ...state, revoked: true }
+    case UNREVOKE:
+      return { ...state, revoked: false }
+    default:
+      return state
+  }
+}

--- a/mobile/src/reducers/index.js
+++ b/mobile/src/reducers/index.js
@@ -5,8 +5,10 @@ import { reducers } from '../../../src/reducers'
 import { settings } from './settings'
 import { mediaBackup } from './mediaBackup'
 import { ui } from './ui'
+import { authorization } from './authorization'
 
 const mobile = combineReducers({
+  authorization,
   settings,
   mediaBackup,
   ui

--- a/mobile/test/reducers/authorization.spec.js
+++ b/mobile/test/reducers/authorization.spec.js
@@ -1,0 +1,14 @@
+import { authorization as reducer } from '../../src/reducers/authorization'
+import { unrevokeClient, revokeClient } from '../../src/actions/authorization'
+
+describe('authorization state', () => {
+  it('should set the revoked flag', () => {
+    expect(reducer(undefined, revokeClient()))
+    .toEqual({ revoked: true })
+  })
+
+  it('should set the revoked flag', () => {
+    expect(reducer(undefined, unrevokeClient()))
+    .toEqual({ revoked: false })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "classnames": "^2.2.0",
     "cozy-bar": "3.0.0-beta9",
-    "cozy-client-js": "0.1.4",
+    "cozy-client-js": "0.1.5",
     "cozy-ui": "3.0.0-beta13",
     "date-fns": "^1.22.0",
     "filesize": "^3.3.0",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -140,6 +140,12 @@
         "offline": "You should be connected to open this file",
         "noapp": "No application can open this file"
       }
+    },
+    "revoked": {
+      "title": "Access revoked",
+      "description": "It appears you revoked this device from your Cozy. If you didn't, please let us know at contact@cozycloud.cc. All your local data related to your Cozy will be removed.",
+      "loginagain": "Log in again",
+      "logout": "Log out"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,9 +1419,9 @@ cozy-bar@3.0.0-beta9:
   dependencies:
     node-polyglot "^2.2.2"
 
-cozy-client-js@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.1.4.tgz#57f4ae8ee9dff6814bd0cf1e1b4b6fc4574055f4"
+cozy-client-js@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.1.5.tgz#7e389d3bee4801a93cfc545ea1132826c279d180"
 
 cozy-ui@3.0.0-beta13:
   version "3.0.0-beta13"


### PR DESCRIPTION
To unregister a device, you need to retrieve the `device id` then `DELETE` this device:

```
OAUTH_TOKEN=$(./cozy-stack instances token-oauth cozy.local:8080 \
$(./cozy-stack instances client-oauth cozy.local:8080 \
http://localhost curl curl) 'io.cozy.oauth.clients')

http http://cozy.local:8080/settings/clients \
--auth user:$OAUTH_TOKEN

http DELETE http://cozy.local:8080/settings/clients/17d49c2fef1f1b951635881e3bc0d1b12 \
--auth user:$OAUTH_TOKEN
```

Here is the scenario:

1. open the android app
1. go through the onboarding
1. your device is registered
1. make above commands to unregister the client
1. restart the android app
1. you should see the onboarding screen

I don't know yet how to manage revocation during app usage.

*hints:*

- `cozy-client-js` throws an error with a specific message on `4xx` HTTP error saying the device is revoked. See https://github.com/cozy/cozy-client-js/pull/96
- but when do we get this error if we use pouchDB data? On the next sync? So it has to be added in the repeated replication flow ;)