### PR TITLE
Fix gesture problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "preact": "^7.1.0",
     "preact-compat": "^3.9.0",
     "raven-js": "^3.10.0",
-    "react-bosonic": "beta",
+    "react-bosonic": "1.0.0-beta6",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",
     "redux": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "preact": "^7.1.0",
     "preact-compat": "^3.9.0",
     "raven-js": "^3.10.0",
-    "react-bosonic": "^1.0.0-beta5",
+    "react-bosonic": "beta",
     "react-redux": "^5.0.1",
     "react-router": "^3.0.0",
     "redux": "^3.6.0",

--- a/src/lib/withGestures.jsx
+++ b/src/lib/withGestures.jsx
@@ -9,8 +9,9 @@ const withGestures = (eventHandlers) => {
   return WrappedComponent => {
     return class WithGesturesComponent extends Component {
       componentDidMount () {
-        this.hammer = new Hammer(ReactDOM.findDOMNode(this))
-        this.hammer.get('swipe').set({ direction: Hammer.DIRECTION_VERTICAL })
+        this.hammer = new Hammer.Manager(ReactDOM.findDOMNode(this), {
+          recognizers: [[Hammer.Tap], [Hammer.Swipe,{ direction: Hammer.DIRECTION_ALL }]]
+        })
         this.handlers = eventHandlers(this.props)
         if (shouldListenToSwipe(this.handlers)) {
           this.hammer.on('swipe', e => this.onSwipe(e))

--- a/src/lib/withGestures.jsx
+++ b/src/lib/withGestures.jsx
@@ -10,7 +10,7 @@ const withGestures = (eventHandlers) => {
     return class WithGesturesComponent extends Component {
       componentDidMount () {
         this.hammer = new Hammer.Manager(ReactDOM.findDOMNode(this), {
-          recognizers: [[Hammer.Tap], [Hammer.Swipe,{ direction: Hammer.DIRECTION_ALL }]]
+          recognizers: [[Hammer.Tap], [Hammer.Swipe, { direction: Hammer.DIRECTION_ALL }]]
         })
         this.handlers = eventHandlers(this.props)
         if (shouldListenToSwipe(this.handlers)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5151,7 +5151,7 @@ react-addons-test-utils@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-bosonic@beta:
+react-bosonic@1.0.0-beta6:
   version "1.0.0-beta6"
   resolved "https://registry.yarnpkg.com/react-bosonic/-/react-bosonic-1.0.0-beta6.tgz#3be25245c811402d2bdf8a71c9996e87a87361b1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,12 +930,11 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bosonic@^2.0.0-beta4:
-  version "2.0.0-beta4"
-  resolved "https://registry.yarnpkg.com/bosonic/-/bosonic-2.0.0-beta4.tgz#470f92e761b54856bc2264ebd2b74766f6e4942a"
+bosonic@^2.0.0-beta5:
+  version "2.0.0-beta5"
+  resolved "https://registry.yarnpkg.com/bosonic/-/bosonic-2.0.0-beta5.tgz#f926fec85b09a46d24d25f017451041ca6e124b8"
   dependencies:
     document-register-element "^1.2.0"
-    pepjs "^0.4.2"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -1424,9 +1423,9 @@ cozy-client-js@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.1.1.tgz#f7e98ed288915a91011270cf9f29b30e0bbb8e93"
 
-cozy-ui@3.0.0-beta12:
-  version "3.0.0-beta12"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta12.tgz#1f67a7b582f7090ce1ff701e159da1b5084f6fba"
+cozy-ui@3.0.0-beta13:
+  version "3.0.0-beta13"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta13.tgz#80697c7a79a33f31f6c4de7f0e43a434783d8060"
   dependencies:
     classnames "^2.2.5"
     md5 "^2.2.0"
@@ -4565,10 +4564,6 @@ pbkdf2-compat@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz#b6e0c8fa99494d94e0511575802a59a5c142f288"
 
-pepjs@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/pepjs/-/pepjs-0.4.2.tgz#13264eea894984ff423c83e40d2fa4e1dec1c9fa"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -5156,11 +5151,11 @@ react-addons-test-utils@^15.4.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-bosonic@^1.0.0-beta5:
-  version "1.0.0-beta5"
-  resolved "https://registry.yarnpkg.com/react-bosonic/-/react-bosonic-1.0.0-beta5.tgz#002994ea724a6a0e0803d4272b3b5360df19ad21"
+react-bosonic@beta:
+  version "1.0.0-beta6"
+  resolved "https://registry.yarnpkg.com/react-bosonic/-/react-bosonic-1.0.0-beta6.tgz#3be25245c811402d2bdf8a71c9996e87a87361b1"
   dependencies:
-    bosonic "^2.0.0-beta4"
+    bosonic "^2.0.0-beta5"
     classnames "^2.2.5"
     document-register-element "^1.2.0"
     preact "^7.1.0"


### PR DESCRIPTION
Post-mortem, for anyone curious:
When viewing the file action menu, you're supposed to be able to tap the background or do a swipe down gesture to dismiss the menu. This worked fine during our tests, but not in production, not on the iphone simulator, etc.

One of our dependencies was injecting a polyfill for PointerEvents. This caused `hammer` to rely on them to detect gestures. However, the polyfill in question requires that elements for which you want PointerEvents be marked with a special attribute, which we didn't use, and so no PointerEvents were fired, and Hammer wasn't doing anything.

We didn't see the problem in dev because we were either using browsers that natively support PointerEvents, or because the polyfill was being blocked for CSP reasons.

Anyway, tested in Firefox, Chrome and Safari iOS, so I'm pretty confident it's fixed.

I also took the opportunity to disable all the Hammer recognizers we don't use at the moment.