### PR TITLE
Feat: The Media Backup Folder is customizable

### DIFF
--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -25,7 +25,6 @@ async function getDirID (dir) {
 }
 
 export const mediaBackup = (dir) => async (dispatch, getState) => {
-  dispatch(startMediaUpload())
   let photos = await getFilteredPhotos()
   const alreadyUploaded = getState().mobile.mediaBackup.uploaded
   const dirID = await getDirID(dir)
@@ -46,5 +45,4 @@ export const mediaBackup = (dir) => async (dispatch, getState) => {
       })
     }
   }
-  dispatch(endMediaUpload())
 }

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -15,11 +15,12 @@ export const mediaBackup = () => async (dispatch, getState) => {
   dispatch(startMediaUpload())
   let photos = await getFilteredPhotos()
   const alreadyUploaded = getState().mobile.mediaBackup.uploaded
+  const dirID = 'io.cozy.files.root-dir'
   for (let photo of photos) {
     if (!alreadyUploaded.includes(photo.id)) {
       const blob = await getBlob(photo)
       const options = {
-        dirID: 'io.cozy.files.root-dir',
+        dirID,
         name: photo.fileName
       }
       await cozy.client.files.create(blob, options).then(() => {

--- a/mobile/src/components/Settings.jsx
+++ b/mobile/src/components/Settings.jsx
@@ -22,7 +22,7 @@ export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages,
       <SubCategory id={'backupImages'} title={t('mobile.settings.media_backup.images.title')}
         label={t('mobile.settings.media_backup.images.label')}
         value={<input type='checkbox' checked={backupImages} onChange={setBackupImages} />} />
-      <button onclick={launchBackup}>
+      <button onclick={() => launchBackup(t('mobile.settings.media_backup.media_folder'))}>
         {t('mobile.settings.media_backup.launch')}
         {mediaUploading && <div className={styles['media-uploading']} />}
       </button>

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -14,9 +14,9 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  launchBackup: () => {
+  launchBackup: (dir) => {
     dispatch(startMediaUpload())
-    dispatch(mediaBackup('Camera'))
+    dispatch(mediaBackup(dir))
     .then(() => dispatch(endMediaUpload()))
     .catch(() => dispatch(endMediaUpload()))
   },

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import Settings from '../components/Settings'
 import { setBackupImages } from '../actions/settings'
 import { showUnlinkConfirmation, hideUnlinkConfirmation, unlink } from '../actions/unlink'
-import { mediaBackup } from '../actions/mediaBackup'
+import { mediaBackup, startMediaUpload, endMediaUpload } from '../actions/mediaBackup'
 
 const mapStateToProps = (state, ownProps) => ({
   mediaUploading: state.mobile.mediaBackup.uploading,
@@ -14,7 +14,12 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  launchBackup: () => dispatch(mediaBackup('Camera')),
+  launchBackup: () => {
+    dispatch(startMediaUpload())
+    dispatch(mediaBackup('Camera'))
+    .then(() => dispatch(endMediaUpload()))
+    .catch(() => dispatch(endMediaUpload()))
+  },
   showUnlinkConfirmation: () => dispatch(showUnlinkConfirmation()),
   hideUnlinkConfirmation: () => dispatch(hideUnlinkConfirmation()),
   unlink: (client) => {

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -14,7 +14,7 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  launchBackup: () => dispatch(mediaBackup()),
+  launchBackup: () => dispatch(mediaBackup('Camera')),
   showUnlinkConfirmation: () => dispatch(showUnlinkConfirmation()),
   hideUnlinkConfirmation: () => dispatch(hideUnlinkConfirmation()),
   unlink: (client) => {

--- a/mobile/src/lib/media.js
+++ b/mobile/src/lib/media.js
@@ -71,7 +71,7 @@ export const getPhotos = async () => {
 export const getFilteredPhotos = async () => {
   let photos = await getPhotos()
 
-  if (window.cordova.platformId === 'android') {
+  if (hasCordovaPlugin() && window.cordova.platformId === 'android') {
     photos = photos.filter((photo) => photo.id.indexOf('DCIM') !== -1)
   }
 

--- a/mobile/src/lib/media.js
+++ b/mobile/src/lib/media.js
@@ -19,7 +19,7 @@ export const requestAuthorization = async () => {
       )
     })
   }
-  return false
+  return Promise.resolve(false)
 }
 
 export const getBlob = async (libraryItem) => {
@@ -33,7 +33,7 @@ export const getBlob = async (libraryItem) => {
     })
   }
 
-  return ''
+  return Promise.resolve('')
 }
 
 export const getPhotos = async () => {
@@ -65,7 +65,7 @@ export const getPhotos = async () => {
     })
   }
 
-  return defaultReturn
+  return Promise.resolve(defaultReturn)
 }
 
 export const getFilteredPhotos = async () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -125,6 +125,7 @@
         }
       },
       "media_backup": {
+        "media_folder": "Camera",
         "title": "Media Backup",
         "images": {
           "title": "Backup images",


### PR DESCRIPTION
With this PR, media are not backed up in the root folder, but
in the Media Backup Folder, customizable in `en.json` file with `mobile.settings.media_backup.media_folder` key.

Some changes:
-    feat: The Media Backup Folder is i18nizable
-    refactor: move loading behavior inside the container
-    fix: Promise must be always returned
-    fix: Check Cordova context before using a plugin
-    feat: backup Media in /Camera folder
-    refactor: dirID as a variable