### PR TITLE
feat: enhance offline behavior

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,6 +1,6 @@
 /* global cozy, __ALLOW_HTTP__ */
 
-import { initClient } from '../lib/cozy-helper'
+import { initClient, refreshFolder } from '../lib/cozy-helper'
 import { onRegistered } from '../lib/registration'
 import { logException } from '../lib/crash-reporter'
 
@@ -75,13 +75,13 @@ export const registerDevice = () => async (dispatch, getState) => {
   await cozy.client.authorize().then(async ({ client }) => {
     dispatch(unrevokeClient())
     dispatch(setClient(client))
-    await cozy.client.offline.replicateFromCozy('io.cozy.files')
     const options = {
       onError: (err) => {
         console.log('on error fron the client', err)
         console.warn(`Your device is no more connected to your server: ${getState().mobile.settings.serverUrl}`)
         dispatch(revokeClient())
-      }
+      },
+      onComplete: refreshFolder(dispatch, getState)
     }
     cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
   }).catch(err => {

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -2,6 +2,8 @@
 
 import { LocalStorage as Storage } from 'cozy-client-js'
 
+import { openFolder } from '../../../src/actions'
+
 const getStorage = () => new Storage()
 const getClientName = device => `Cozy Files Application on ${device} (${Math.random().toString(36).slice(2)})`
 
@@ -23,7 +25,6 @@ export const initClient = (url, onRegister = null, device = 'Device') => {
     console.log(`Cozy Client initializes a connection with ${url}`)
     cozy.client.init({
       cozyURL: url,
-      offline: {doctypes: ['io.cozy.files']},
       oauth: getAuth(onRegister, device)
     })
   }
@@ -62,5 +63,13 @@ export function resetClient () {
   // reset cozy-client-js
   if (cozy.client._storage) {
     cozy.client._storage.clear()
+  }
+}
+
+export function refreshFolder (dispatch, getState) {
+  return result => {
+    if (result.docs_written !== 0) {
+      dispatch(openFolder(getState().folder.id))
+    }
   }
 }

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -19,7 +19,7 @@ import filesApp from './reducers'
 import MobileAppRoute from './components/MobileAppRoute'
 
 import { loadState, saveState } from './lib/localStorage'
-import { initClient, initBar, isClientRegistered, resetClient } from './lib/cozy-helper'
+import { initClient, initBar, isClientRegistered, resetClient, refreshFolder } from './lib/cozy-helper'
 import { revokeClient } from './actions/authorization'
 
 const loggerMiddleware = createLogger()
@@ -59,7 +59,8 @@ const renderAppWithPersistedState = persistedState => {
       isClientRegistered(client).then(clientIsRegistered => {
         if (clientIsRegistered) {
           const options = {
-            onError: onError(store, callback)
+            onError: onError(store, callback),
+            onComplete: refreshFolder(store.dispatch, store.getState)
           }
           cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
           initBar()


### PR DESCRIPTION
When a replication is complete AND when there is some new document(s), then
we refresh the current folder's file list by dispatching an action creator.

And on startup, we don't get localfile first as in that case we have to need the end of the replication to display files.
Instead we load remote files and start a repeated replication. When the first replication is going to start, it creates a local database.

It is related to https://github.com/cozy/cozy-client-js/pull/109

I think it's better, what do **you** think?