### PR TITLE
[fix] Prevent ghostclicks after taps

### DIFF
--- a/src/containers/FileActionMenu.jsx
+++ b/src/containers/FileActionMenu.jsx
@@ -91,7 +91,7 @@ const ActionMenu = withGestures(
 
 const Backdrop = withGestures(
   ownProps => ({
-    tap: () => ownProps.onClose()
+    tap: e => setTimeout(ownProps.onClose)// timeout is used to prevent the infamous ghostclick
   })
 )(() => <div className={styles['fil-actionmenu-backdrop']} />)
 


### PR DESCRIPTION
After a tap, a click event is *also* fired not long after -- the infamous GhostClick. See the last tip here: http://hammerjs.github.io/tips/

We could prevent the click as wildly suggested elsewhere, but that requires a bit of code and doesn't integrate very well with our current set-up.
Instead, I'm slighty delaying the hiding of the backdrop, so the ghost click happens on the backdrop and has no side effects.