### PR TITLE
feat: add option to allow backup media only on wifi

### DIFF
--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -58,4 +58,5 @@
     <plugin name="cordova-plugin-photo-library" spec="2.0.3">
         <variable name="PHOTO_LIBRARY_USAGE_DESCRIPTION" value="This app requires access to the photo library." />
     </plugin>
+    <plugin name="cordova-plugin-network-information" spec="~1.3.2" />
 </widget>

--- a/mobile/config.xml
+++ b/mobile/config.xml
@@ -58,5 +58,5 @@
     <plugin name="cordova-plugin-photo-library" spec="2.0.3">
         <variable name="PHOTO_LIBRARY_USAGE_DESCRIPTION" value="This app requires access to the photo library." />
     </plugin>
-    <plugin name="cordova-plugin-network-information" spec="~1.3.2" />
+    <plugin name="cordova-plugin-network-information" spec="1.3.2" />
 </widget>

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -29,7 +29,7 @@ async function getDirID (dir) {
 export const mediaBackup = (dir) => async (dispatch, getState) => {
   const connectionType = getConnectionType()
   dispatch(setConnectionState(connectionType))
-  if (backupAllowed(getConnectionType(), getState().mobile.settings.wifiOnly)) {
+  if (backupAllowed(connectionType, getState().mobile.settings.wifiOnly)) {
     let photos = await getFilteredPhotos()
     const alreadyUploaded = getState().mobile.mediaBackup.uploaded
     const dirID = await getDirID(dir)

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -1,7 +1,8 @@
 /* global cozy */
 
 import { getFilteredPhotos, getBlob } from '../lib/media'
-import { onWifi } from '../lib/network'
+import { backupAllowed, getConnectionType } from '../lib/network'
+import { setConnectionState } from '../actions/network'
 import { HTTP_CODE_CONFLICT } from '../../../src/actions'
 
 export const MEDIA_UPLOAD_START = 'MEDIA_UPLOAD_START'
@@ -26,7 +27,9 @@ async function getDirID (dir) {
 }
 
 export const mediaBackup = (dir) => async (dispatch, getState) => {
-  if (getState().mobile.settings.wifiOnly && !onWifi()) {
+  const connectionType = getConnectionType()
+  dispatch(setConnectionState(connectionType))
+  if (backupAllowed(getConnectionType(), getState().mobile.settings.wifiOnly)) {
     let photos = await getFilteredPhotos()
     const alreadyUploaded = getState().mobile.mediaBackup.uploaded
     const dirID = await getDirID(dir)

--- a/mobile/src/actions/network.js
+++ b/mobile/src/actions/network.js
@@ -1,0 +1,7 @@
+export const CONNECTION = 'CONNECTION'
+
+export const setConnectionState = value => ({ type: CONNECTION, value })
+
+export const onConnectionChange = (dispatch, getConnectionType) => () => {
+  dispatch(setConnectionState(getConnectionType()))
+}

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -7,6 +7,7 @@ import { logException } from '../lib/crash-reporter'
 export const SET_URL = 'SET_URL'
 export const BACKUP_IMAGES_DISABLE = 'BACKUP_IMAGES_DISABLE'
 export const BACKUP_IMAGES_ENABLE = 'BACKUP_IMAGES_ENABLE'
+export const WIFI_ONLY = 'WIFI_ONLY'
 export const ERROR = 'ERROR'
 export const SET_CLIENT = 'SET_CLIENT'
 
@@ -45,6 +46,7 @@ export const setBackupImages = (value) => {
     return disableBackupImages()
   }
 }
+export const setWifiOnly = value => ({ type: WIFI_ONLY, value })
 
 // errors
 

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -5,8 +5,7 @@ import { onRegistered } from '../lib/registration'
 import { logException } from '../lib/crash-reporter'
 
 export const SET_URL = 'SET_URL'
-export const BACKUP_IMAGES_DISABLE = 'BACKUP_IMAGES_DISABLE'
-export const BACKUP_IMAGES_ENABLE = 'BACKUP_IMAGES_ENABLE'
+export const BACKUP_IMAGES = 'BACKUP_IMAGES'
 export const WIFI_ONLY = 'WIFI_ONLY'
 export const ERROR = 'ERROR'
 export const SET_CLIENT = 'SET_CLIENT'
@@ -37,15 +36,9 @@ export const checkURL = url => dispatch => {
 
 // backup images
 
-export const enableBackupImages = () => ({type: BACKUP_IMAGES_ENABLE})
-export const disableBackupImages = () => ({type: BACKUP_IMAGES_DISABLE})
-export const setBackupImages = (value) => {
-  if (value) {
-    return enableBackupImages()
-  } else {
-    return disableBackupImages()
-  }
-}
+export const enableBackupImages = () => setBackupImages(true)
+export const disableBackupImages = () => setBackupImages(false)
+export const setBackupImages = value => ({type: BACKUP_IMAGES, value})
 export const setWifiOnly = value => ({ type: WIFI_ONLY, value })
 
 // errors

--- a/mobile/src/components/Settings.jsx
+++ b/mobile/src/components/Settings.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Modal from 'cozy-ui/react/Modal'
 import styles from '../styles/settings'
 import { translate } from '../../../src/lib/I18n'
-import { onWifi } from '../lib/network'
 
 const SubCategory = ({ id, label, value, title }) => (
   <div>
@@ -14,7 +13,7 @@ const SubCategory = ({ id, label, value, title }) => (
   </div>
 )
 
-export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages, client, showUnlinkConfirmation, displayUnlinkConfirmation, hideUnlinkConfirmation, unlink, mediaUploading, launchBackup, wifiOnly, setWifiOnly }) => (
+export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages, client, showUnlinkConfirmation, displayUnlinkConfirmation, hideUnlinkConfirmation, unlink, mediaUploading, launchBackup, wifiOnly, setWifiOnly, backupAllowed }) => (
   <div>
     <div className={styles['fil-content-row']} />
     <div className={styles['settings']}>
@@ -26,7 +25,7 @@ export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages,
       <SubCategory id={'backupOnlyWifi'} title={t('mobile.settings.media_backup.wifi.title')}
         label={t('mobile.settings.media_backup.wifi.label')}
         value={<input type='checkbox' checked={wifiOnly} onChange={setWifiOnly} />} />
-      <button onclick={() => launchBackup(t('mobile.settings.media_backup.media_folder'))} className={'coz-btn coz-btn--regular'} disabled={wifiOnly && !onWifi()}>
+      <button onclick={() => launchBackup(t('mobile.settings.media_backup.media_folder'))} className={'coz-btn coz-btn--regular'} disabled={!backupAllowed}>
         {t('mobile.settings.media_backup.launch')}
         {mediaUploading && <div className={styles['media-uploading']} />}
       </button>

--- a/mobile/src/components/Settings.jsx
+++ b/mobile/src/components/Settings.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import Modal from 'cozy-ui/react/Modal'
 import styles from '../styles/settings'
 import { translate } from '../../../src/lib/I18n'
+import { onWifi } from '../lib/network'
 
 const SubCategory = ({ id, label, value, title }) => (
   <div>
@@ -13,7 +14,7 @@ const SubCategory = ({ id, label, value, title }) => (
   </div>
 )
 
-export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages, client, showUnlinkConfirmation, displayUnlinkConfirmation, hideUnlinkConfirmation, unlink, mediaUploading, launchBackup }) => (
+export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages, client, showUnlinkConfirmation, displayUnlinkConfirmation, hideUnlinkConfirmation, unlink, mediaUploading, launchBackup, wifiOnly, setWifiOnly }) => (
   <div>
     <div className={styles['fil-content-row']} />
     <div className={styles['settings']}>
@@ -22,7 +23,10 @@ export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages,
       <SubCategory id={'backupImages'} title={t('mobile.settings.media_backup.images.title')}
         label={t('mobile.settings.media_backup.images.label')}
         value={<input type='checkbox' checked={backupImages} onChange={setBackupImages} />} />
-      <button onclick={() => launchBackup(t('mobile.settings.media_backup.media_folder'))}>
+      <SubCategory id={'backupOnlyWifi'} title={t('mobile.settings.media_backup.wifi.title')}
+        label={t('mobile.settings.media_backup.wifi.label')}
+        value={<input type='checkbox' checked={wifiOnly} onChange={setWifiOnly} />} />
+      <button onclick={() => launchBackup(t('mobile.settings.media_backup.media_folder'))} className={'coz-btn coz-btn--regular'} disabled={wifiOnly && !onWifi()}>
         {t('mobile.settings.media_backup.launch')}
         {mediaUploading && <div className={styles['media-uploading']} />}
       </button>

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 import Settings from '../components/Settings'
-import { setBackupImages } from '../actions/settings'
+import { setBackupImages, setWifiOnly } from '../actions/settings'
 import { showUnlinkConfirmation, hideUnlinkConfirmation, unlink } from '../actions/unlink'
 import { mediaBackup, startMediaUpload, endMediaUpload } from '../actions/mediaBackup'
 
@@ -10,7 +10,8 @@ const mapStateToProps = (state, ownProps) => ({
   serverUrl: state.mobile.settings.serverUrl,
   backupImages: state.mobile.settings.backupImages,
   displayUnlinkConfirmation: state.mobile.ui.displayUnlinkConfirmation,
-  client: state.mobile.settings.client
+  client: state.mobile.settings.client,
+  wifiOnly: state.mobile.settings.wifiOnly
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
@@ -28,6 +29,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   },
   setBackupImages: (e) => {
     dispatch(setBackupImages(e.target.checked))
+  },
+  setWifiOnly: (e) => {
+    dispatch(setWifiOnly(e.target.checked))
   }
 })
 

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -3,6 +3,7 @@ import Settings from '../components/Settings'
 import { setBackupImages, setWifiOnly } from '../actions/settings'
 import { showUnlinkConfirmation, hideUnlinkConfirmation, unlink } from '../actions/unlink'
 import { mediaBackup, startMediaUpload, endMediaUpload } from '../actions/mediaBackup'
+import { backupAllowed } from '../lib/network'
 
 const mapStateToProps = (state, ownProps) => ({
   mediaUploading: state.mobile.mediaBackup.uploading,
@@ -11,7 +12,8 @@ const mapStateToProps = (state, ownProps) => ({
   backupImages: state.mobile.settings.backupImages,
   displayUnlinkConfirmation: state.mobile.ui.displayUnlinkConfirmation,
   client: state.mobile.settings.client,
-  wifiOnly: state.mobile.settings.wifiOnly
+  wifiOnly: state.mobile.settings.wifiOnly,
+  backupAllowed: backupAllowed(state.mobile.network.connection, state.mobile.settings.wifiOnly)
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/mobile/src/lib/network.js
+++ b/mobile/src/lib/network.js
@@ -1,3 +1,12 @@
-export function onWifi () {
-  return window.navigator.connection && window.navigator.connection.type === window.Connection.WIFI
+export const watchNetworkState = (onConnectionChange) => {
+  document.addEventListener('offline', onConnectionChange, false)
+  document.addEventListener('online', onConnectionChange, false)
 }
+
+export const hasCordovaPlugin = window.navigator.connection !== undefined && window.Connection !== undefined
+
+export const getConnectionType = () => hasCordovaPlugin ? navigator.connection.type : 'wifi'
+
+export const onWifi = connection => connection === 'wifi'
+
+export const backupAllowed = (connectionType, wifiOnly) => onWifi(connectionType) || !wifiOnly

--- a/mobile/src/lib/network.js
+++ b/mobile/src/lib/network.js
@@ -1,3 +1,12 @@
+export const UNKNOWN = window.Connection ? window.Connection.UNKNOWN : 'unknown'
+export const ETHERNET = window.Connection ? window.Connection.ETHERNET : 'ethernet'
+export const WIFI = window.Connection ? window.Connection.WIFI : 'wifi'
+export const CELL_2G = window.Connection ? window.Connection.CELL_2G : '2g'
+export const CELL_3G = window.Connection ? window.Connection.CELL_3G : '3g'
+export const CELL_4G = window.Connection ? window.Connection.CELL_4G : '4g'
+export const CELL = window.Connection ? window.Connection.CELL : 'cellular'
+export const NONE = window.Connection ? window.Connection.NONE : 'none'
+
 export const watchNetworkState = (onConnectionChange) => {
   document.addEventListener('offline', onConnectionChange, false)
   document.addEventListener('online', onConnectionChange, false)
@@ -5,8 +14,8 @@ export const watchNetworkState = (onConnectionChange) => {
 
 export const hasCordovaPlugin = window.navigator.connection !== undefined && window.Connection !== undefined
 
-export const getConnectionType = () => hasCordovaPlugin ? navigator.connection.type : 'wifi'
+export const getConnectionType = () => hasCordovaPlugin ? navigator.connection.type : WIFI
 
-export const onWifi = connection => connection === 'wifi'
+export const onWifi = connection => connection === WIFI
 
 export const backupAllowed = (connectionType, wifiOnly) => onWifi(connectionType) || !wifiOnly

--- a/mobile/src/lib/network.js
+++ b/mobile/src/lib/network.js
@@ -1,0 +1,3 @@
+export function onWifi () {
+  return window.navigator.connection && window.navigator.connection.type === window.Connection.WIFI
+}

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -20,6 +20,8 @@ import MobileAppRoute from './components/MobileAppRoute'
 
 import { loadState, saveState } from './lib/localStorage'
 import { initClient, initBar, isClientRegistered, resetClient, refreshFolder, onError } from './lib/cozy-helper'
+import { watchNetworkState, getConnectionType } from './lib/network'
+import { onConnectionChange, setConnectionState } from './actions/network'
 
 const loggerMiddleware = createLogger()
 
@@ -44,6 +46,8 @@ const renderAppWithPersistedState = persistedState => {
   }))
 
   initClient(store.getState().mobile.settings.serverUrl)
+  store.dispatch(setConnectionState(getConnectionType()))
+  watchNetworkState(onConnectionChange(store.dispatch, getConnectionType))
 
   function requireSetup (nextState, replace, callback) {
     const client = store.getState().mobile.settings.client

--- a/mobile/src/reducers/index.js
+++ b/mobile/src/reducers/index.js
@@ -6,8 +6,10 @@ import { settings } from './settings'
 import { mediaBackup } from './mediaBackup'
 import { ui } from './ui'
 import { authorization } from './authorization'
+import { network } from './network'
 
 const mobile = combineReducers({
+  network,
   authorization,
   settings,
   mediaBackup,

--- a/mobile/src/reducers/mediaBackup.js
+++ b/mobile/src/reducers/mediaBackup.js
@@ -1,5 +1,6 @@
 import { INIT_STATE } from '../actions'
 import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS } from '../actions/mediaBackup'
+import { ON_WIFI } from '../actions/network'
 
 export const initialState = {
   uploading: false,
@@ -14,6 +15,8 @@ export const mediaBackup = (state = initialState, action) => {
       return { ...state, uploading: false }
     case IMAGE_UPLOAD_SUCCESS:
       return { ...state, uploaded: [...state.uploaded, action.id] }
+    case ON_WIFI:
+      return { ...state, onWifi: action.value }
     case INIT_STATE:
       return initialState
     default:

--- a/mobile/src/reducers/network.js
+++ b/mobile/src/reducers/network.js
@@ -1,0 +1,10 @@
+import { CONNECTION } from '../actions/network'
+
+export const network = (state = {}, action) => {
+  switch (action.type) {
+    case CONNECTION:
+      return { ...state, connection: action.value }
+    default:
+      return state
+  }
+}

--- a/mobile/src/reducers/settings.js
+++ b/mobile/src/reducers/settings.js
@@ -1,5 +1,5 @@
 import { INIT_STATE } from '../actions'
-import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT, WIFI_ONLY } from '../actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES, SET_CLIENT, WIFI_ONLY } from '../actions/settings'
 
 export const initialState = {
   serverUrl: '',
@@ -11,10 +11,8 @@ export const settings = (state = initialState, action) => {
   switch (action.type) {
     case SET_URL:
       return { ...state, serverUrl: action.url, error: null, authorized: false }
-    case BACKUP_IMAGES_DISABLE:
-      return { ...state, backupImages: false }
-    case BACKUP_IMAGES_ENABLE:
-      return { ...state, backupImages: true }
+    case BACKUP_IMAGES:
+      return { ...state, backupImages: action.value }
     case ERROR:
       return { ...state, error: action.error }
     case INIT_STATE:

--- a/mobile/src/reducers/settings.js
+++ b/mobile/src/reducers/settings.js
@@ -1,5 +1,5 @@
 import { INIT_STATE } from '../actions'
-import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT } from '../actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT, WIFI_ONLY } from '../actions/settings'
 
 export const initialState = {
   serverUrl: '',
@@ -21,6 +21,8 @@ export const settings = (state = initialState, action) => {
       return initialState
     case SET_CLIENT:
       return { ...state, client: action.client, authorized: true }
+    case WIFI_ONLY:
+      return { ...state, wifiOnly: action.value }
     default:
       return state
   }

--- a/mobile/test/actions/settings.spec.js
+++ b/mobile/test/actions/settings.spec.js
@@ -2,19 +2,19 @@ import { mockStore } from '../../../test/helpers'
 import {
   SET_URL, setUrl, checkURL,
   SET_CLIENT, setClient,
-  BACKUP_IMAGES_ENABLE, BACKUP_IMAGES_DISABLE, enableBackupImages, disableBackupImages, setBackupImages,
+  BACKUP_IMAGES, enableBackupImages, disableBackupImages, setBackupImages,
   OnBoardingError, wrongAddressError, ERROR, wrongAddressErrorMsg
 } from '../../src/actions/settings'
 
 describe('backup images actions creators', () => {
   it('should create an action to enable backup images', () => {
-    const expectedAction = { type: BACKUP_IMAGES_ENABLE }
+    const expectedAction = { type: BACKUP_IMAGES, value: true }
     expect(enableBackupImages()).toEqual(expectedAction)
     expect(setBackupImages(true)).toEqual(expectedAction)
   })
 
   it('should create an action to disable backup images', () => {
-    const expectedAction = { type: BACKUP_IMAGES_DISABLE }
+    const expectedAction = { type: BACKUP_IMAGES, value: false }
     expect(disableBackupImages()).toEqual(expectedAction)
     expect(setBackupImages(false)).toEqual(expectedAction)
   })

--- a/mobile/test/actions/settings.spec.js
+++ b/mobile/test/actions/settings.spec.js
@@ -1,22 +1,32 @@
 import { mockStore } from '../../../test/helpers'
+import reducer from '../../src/reducers/settings'
 import {
   SET_URL, setUrl, checkURL,
   SET_CLIENT, setClient,
-  BACKUP_IMAGES, enableBackupImages, disableBackupImages, setBackupImages,
+  setBackupImages,
+  setWifiOnly,
   OnBoardingError, wrongAddressError, ERROR, wrongAddressErrorMsg
 } from '../../src/actions/settings'
 
 describe('backup images actions creators', () => {
-  it('should create an action to enable backup images', () => {
-    const expectedAction = { type: BACKUP_IMAGES, value: true }
-    expect(enableBackupImages()).toEqual(expectedAction)
-    expect(setBackupImages(true)).toEqual(expectedAction)
+  it('should enable backup images', () => {
+    const state = reducer({}, setBackupImages(true))
+    expect(state).toEqual({backupImages: true})
   })
 
-  it('should create an action to disable backup images', () => {
-    const expectedAction = { type: BACKUP_IMAGES, value: false }
-    expect(disableBackupImages()).toEqual(expectedAction)
-    expect(setBackupImages(false)).toEqual(expectedAction)
+  it('should disable backup images', () => {
+    const state = reducer({}, setBackupImages(false))
+    expect(state).toEqual({backupImages: false})
+  })
+
+  it('should enable backup on wifi only', () => {
+    const state = reducer({}, setWifiOnly(true))
+    expect(state).toEqual({wifiOnly: true})
+  })
+
+  it('should disable backup on wifi only', () => {
+    const state = reducer({}, setWifiOnly(false))
+    expect(state).toEqual({wifiOnly: false})
   })
 })
 

--- a/mobile/test/reducers/settings.spec.js
+++ b/mobile/test/reducers/settings.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/settings'
 import { INIT_STATE } from '../../src/actions'
-import { SET_URL, ERROR, BACKUP_IMAGES_DISABLE, BACKUP_IMAGES_ENABLE, SET_CLIENT } from '../../src/actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES, SET_CLIENT } from '../../src/actions/settings'
 
 describe('settings reducers', () => {
   it('should return the initial state', () => {
@@ -15,12 +15,12 @@ describe('settings reducers', () => {
   })
 
   it('should handle BACKUP_IMAGES_DISABLE', () => {
-    expect(reducer({backupImages: true}, {type: BACKUP_IMAGES_DISABLE}))
+    expect(reducer({backupImages: true}, {type: BACKUP_IMAGES, value: false}))
     .toEqual({backupImages: false})
   })
 
   it('should handle BACKUP_IMAGES_ENABLE', () => {
-    expect(reducer({backupImages: false}, {type: BACKUP_IMAGES_ENABLE}))
+    expect(reducer({backupImages: false}, {type: BACKUP_IMAGES, value: true}))
     .toEqual({backupImages: true})
   })
 

--- a/mobile/test/reducers/settings.spec.js
+++ b/mobile/test/reducers/settings.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/settings'
 import { INIT_STATE } from '../../src/actions'
-import { SET_URL, ERROR, BACKUP_IMAGES, SET_CLIENT } from '../../src/actions/settings'
+import { SET_URL, ERROR, SET_CLIENT } from '../../src/actions/settings'
 
 describe('settings reducers', () => {
   it('should return the initial state', () => {
@@ -12,16 +12,6 @@ describe('settings reducers', () => {
     const url = 'http://localhost'
     expect(reducer({serverUrl: '', error: 'defined', authorized: false}, {type: SET_URL, url: url}))
     .toEqual({serverUrl: url, error: null, authorized: false})
-  })
-
-  it('should handle BACKUP_IMAGES_DISABLE', () => {
-    expect(reducer({backupImages: true}, {type: BACKUP_IMAGES, value: false}))
-    .toEqual({backupImages: false})
-  })
-
-  it('should handle BACKUP_IMAGES_ENABLE', () => {
-    expect(reducer({backupImages: false}, {type: BACKUP_IMAGES, value: true}))
-    .toEqual({backupImages: true})
   })
 
   it('should handle ERROR', () => {


### PR DESCRIPTION
We need to:
- [x] add a setting in settings (`wifiOnly`)
- [x] add the connection state in the global state
- [x] check `wifiOnly && !onWifi` to disable backup
- [x] update connection state when connection state is updated ([cordova-plugin-network-information](https://github.com/apache/cordova-plugin-network-information#sample-upload-a-file-depending-on-your-network-state-))

That is more or less what this PR aims to do.