### PR TITLE
feat: revocation Modal has no cross

### DIFF
--- a/mobile/src/containers/RevokableWrapper.jsx
+++ b/mobile/src/containers/RevokableWrapper.jsx
@@ -36,6 +36,7 @@ class RevokableWrapper extends Component {
             cancelAction={() => { this.logout() }}
             validateText={t('mobile.revoked.loginagain')}
             validateAction={() => { this.loginagain() }}
+            withCross={false}
           />
           {children}
         </div>


### PR DESCRIPTION
In https://github.com/cozy/cozy-ui/pull/78 we had a new props to control the cross in the modal.
This PR aims to use it to not display cross in our revocation modal.

![screenshot at 18-29-19](https://cloud.githubusercontent.com/assets/701648/23805823/be8521ce-05bf-11e7-9e64-5a25f46107af.png)