### PR TITLE
feat: add a progression view for media backup

### DIFF
--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -39,13 +39,14 @@ async function getDirID (dir) {
 
 export const mediaBackup = (dir) => async (dispatch, getState) => {
   if (backupAllowed(getState().mobile.settings.wifiOnly)) {
-    let photos = await getFilteredPhotos()
+    const photosOnDevice = await getFilteredPhotos()
     const alreadyUploaded = getState().mobile.mediaBackup.uploaded
+    const photosToUpload = photosOnDevice.filter(photo => !alreadyUploaded.includes(photo.id))
     const dirID = await getDirID(dir)
-    const totalUpload = photos.length - alreadyUploaded.length
+    const totalUpload = photosToUpload.length
     let uploadCounter = 0
-    for (let photo of photos) {
-      if (!alreadyUploaded.includes(photo.id) && backupAllowed(getState().mobile.settings.wifiOnly)) {
+    for (let photo of photosToUpload) {
+      if (backupAllowed(getState().mobile.settings.wifiOnly)) {
         dispatch(currentUploading(photo, uploadCounter++, totalUpload))
         const blob = await getBlob(photo)
         const options = {

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -7,10 +7,22 @@ import { HTTP_CODE_CONFLICT } from '../../../src/actions'
 export const MEDIA_UPLOAD_START = 'MEDIA_UPLOAD_START'
 export const MEDIA_UPLOAD_END = 'MEDIA_UPLOAD_END'
 export const IMAGE_UPLOAD_SUCCESS = 'IMAGE_UPLOAD_SUCCESS'
+export const CURRENT_UPLOAD = 'CURRENT_UPLOAD'
 
 export const startMediaUpload = () => ({ type: MEDIA_UPLOAD_START })
 export const endMediaUpload = () => ({ type: MEDIA_UPLOAD_END })
-export const successImageUpload = (image) => ({ type: IMAGE_UPLOAD_SUCCESS, id: image.id })
+export const successImageUpload = (media) => ({ type: IMAGE_UPLOAD_SUCCESS, id: media.id })
+export const currentUploading = (media, uploadCounter, totalUpload) => (
+  {
+    type: CURRENT_UPLOAD,
+    media,
+    message: 'alert.media_upload',
+    messageData: {
+      upload_counter: uploadCounter,
+      total_upload: totalUpload
+    }
+  }
+)
 
 async function getDirID (dir) {
   const targetDirectory = await cozy.client.files.createDirectory({
@@ -30,8 +42,11 @@ export const mediaBackup = (dir) => async (dispatch, getState) => {
     let photos = await getFilteredPhotos()
     const alreadyUploaded = getState().mobile.mediaBackup.uploaded
     const dirID = await getDirID(dir)
+    const totalUpload = photos.length - alreadyUploaded.length
+    let uploadCounter = 0
     for (let photo of photos) {
       if (!alreadyUploaded.includes(photo.id) && backupAllowed(getState().mobile.settings.wifiOnly)) {
+        dispatch(currentUploading(photo, uploadCounter++, totalUpload))
         const blob = await getBlob(photo)
         const options = {
           dirID,

--- a/mobile/src/actions/mediaBackup.js
+++ b/mobile/src/actions/mediaBackup.js
@@ -6,17 +6,17 @@ import { HTTP_CODE_CONFLICT } from '../../../src/actions'
 
 export const MEDIA_UPLOAD_START = 'MEDIA_UPLOAD_START'
 export const MEDIA_UPLOAD_END = 'MEDIA_UPLOAD_END'
-export const IMAGE_UPLOAD_SUCCESS = 'IMAGE_UPLOAD_SUCCESS'
+export const MEDIA_UPLOAD_SUCCESS = 'MEDIA_UPLOAD_SUCCESS'
 export const CURRENT_UPLOAD = 'CURRENT_UPLOAD'
 
 export const startMediaUpload = () => ({ type: MEDIA_UPLOAD_START })
 export const endMediaUpload = () => ({ type: MEDIA_UPLOAD_END })
-export const successImageUpload = (media) => ({ type: IMAGE_UPLOAD_SUCCESS, id: media.id })
+export const successMediaUpload = (media) => ({ type: MEDIA_UPLOAD_SUCCESS, id: media.id })
 export const currentUploading = (media, uploadCounter, totalUpload) => (
   {
     type: CURRENT_UPLOAD,
     media,
-    message: 'alert.media_upload',
+    message: 'mobile.settings.media_backup.media_upload',
     messageData: {
       upload_counter: uploadCounter,
       total_upload: totalUpload
@@ -53,10 +53,10 @@ export const mediaBackup = (dir) => async (dispatch, getState) => {
           name: photo.fileName
         }
         await cozy.client.files.create(blob, options).then(() => {
-          dispatch(successImageUpload(photo))
+          dispatch(successMediaUpload(photo))
         }).catch(err => {
           if (err.status === HTTP_CODE_CONFLICT) {
-            dispatch(successImageUpload(photo))
+            dispatch(successMediaUpload(photo))
           }
           console.log(err)
         })

--- a/mobile/src/components/UploadProgression.jsx
+++ b/mobile/src/components/UploadProgression.jsx
@@ -15,7 +15,10 @@ const UploadProgression = ({t, message, messageData}) => {
             styles[`coz-alert--info`]
           )}
         >
-          <p>{t(message, messageData)}</p>
+          <p>
+            <span class={styles['fil-loading']} />
+            {t(message, messageData)}
+          </p>
         </div>
       </div>
     )

--- a/mobile/src/components/UploadProgression.jsx
+++ b/mobile/src/components/UploadProgression.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import classNames from 'classnames'
+import styles from '../styles/uploadprogression'
+import { translate } from '../../../src/lib/I18n'
+
+const UploadProgression = ({t, message, messageData}) => {
+  if (!message) {
+    return null
+  } else {
+    return (
+      <div className={styles['coz-alerter']}>
+        <div
+          className={classNames(
+            styles['coz-alert'],
+            styles[`coz-alert--info`]
+          )}
+        >
+          <p>{t(message, messageData)}</p>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default translate()(UploadProgression)

--- a/mobile/src/containers/UploadProgression.jsx
+++ b/mobile/src/containers/UploadProgression.jsx
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux'
+import UploadProgression from '../components/UploadProgression'
+
+const mapStateToProps = (state) => ({
+  message: state.mobile.mediaBackup.currentUpload ? state.mobile.mediaBackup.currentUpload.message : undefined,
+  messageData: state.mobile.mediaBackup.currentUpload ? state.mobile.mediaBackup.currentUpload.messageData : undefined
+})
+
+export default connect(mapStateToProps)(UploadProgression)

--- a/mobile/src/reducers/mediaBackup.js
+++ b/mobile/src/reducers/mediaBackup.js
@@ -1,5 +1,5 @@
 import { INIT_STATE } from '../actions'
-import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS, CURRENT_UPLOAD } from '../actions/mediaBackup'
+import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS, CURRENT_UPLOAD } from '../actions/mediaBackup'
 
 export const initialState = {
   uploading: false,
@@ -12,7 +12,7 @@ export const mediaBackup = (state = initialState, action) => {
       return { ...state, uploading: true }
     case MEDIA_UPLOAD_END:
       return { ...state, uploading: false, currentUpload: undefined }
-    case IMAGE_UPLOAD_SUCCESS:
+    case MEDIA_UPLOAD_SUCCESS:
       return { ...state, uploaded: [...state.uploaded, action.id] }
     case CURRENT_UPLOAD:
       return { ...state, currentUpload: { media: action.media, message: action.message, messageData: action.messageData } }

--- a/mobile/src/reducers/mediaBackup.js
+++ b/mobile/src/reducers/mediaBackup.js
@@ -1,5 +1,5 @@
 import { INIT_STATE } from '../actions'
-import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS } from '../actions/mediaBackup'
+import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS, CURRENT_UPLOAD } from '../actions/mediaBackup'
 
 export const initialState = {
   uploading: false,
@@ -11,9 +11,11 @@ export const mediaBackup = (state = initialState, action) => {
     case MEDIA_UPLOAD_START:
       return { ...state, uploading: true }
     case MEDIA_UPLOAD_END:
-      return { ...state, uploading: false }
+      return { ...state, uploading: false, currentUpload: undefined }
     case IMAGE_UPLOAD_SUCCESS:
       return { ...state, uploaded: [...state.uploaded, action.id] }
+    case CURRENT_UPLOAD:
+      return { ...state, currentUpload: { media: action.media, message: action.message, messageData: action.messageData } }
     case INIT_STATE:
       return initialState
     default:

--- a/mobile/src/styles/uploadprogression.styl
+++ b/mobile/src/styles/uploadprogression.styl
@@ -2,3 +2,6 @@
 
 .coz-alerter
   @extends $alerts
+
+  .coz-alert
+    bottom 3em

--- a/mobile/src/styles/uploadprogression.styl
+++ b/mobile/src/styles/uploadprogression.styl
@@ -1,0 +1,4 @@
+@require 'cozy-ui'
+
+.coz-alerter
+  @extends $alerts

--- a/mobile/src/styles/uploadprogression.styl
+++ b/mobile/src/styles/uploadprogression.styl
@@ -5,3 +5,8 @@
 
   .coz-alert
     bottom 3em
+
+.fil-loading
+    @extend $icon-16
+    @extend $icon-spinner-white
+    margin-right 0.5em

--- a/mobile/test/__snapshots__/onboarding.spec.js.snap
+++ b/mobile/test/__snapshots__/onboarding.spec.js.snap
@@ -62,6 +62,41 @@ exports[`Onboarding should render different components 2`] = `
 </div>
 `;
 
+exports[`Onboarding should render the Analytics screen 1`] = `
+<div
+  className="wizard analytics">
+  <header
+    className="wizard-header">
+    <a
+      className="skipLink"
+      onClick={undefined} />
+  </header>
+  <div
+    className="wizard-main">
+    <div
+      className="illustration illustration-trophy" />
+    <h1
+      className="title" />
+    <p
+      className="description" />
+  </div>
+  <footer
+    className="wizard-footer">
+    <button
+      className="coz-btn coz-btn--regular"
+      onClick={undefined}
+      role="button" />
+    <div
+      className="onboarding-breadcrumb">
+      <div
+        className="onboarding-breadcrumb-element" />
+      <div
+        className="onboarding-breadcrumb-element-active" />
+    </div>
+  </footer>
+</div>
+`;
+
 exports[`Onboarding should render the BackupPhotosVideos screen 1`] = `
 <div
   className="wizard photos-backup">

--- a/mobile/test/actions/mediaBackup.spec.js
+++ b/mobile/test/actions/mediaBackup.spec.js
@@ -1,6 +1,6 @@
 import {
-  MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS,
-  startMediaUpload, endMediaUpload, successImageUpload
+  MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS,
+  startMediaUpload, endMediaUpload, successMediaUpload
 } from '../../src/actions/mediaBackup'
 
 describe('mediaBackup actions', () => {
@@ -14,9 +14,9 @@ describe('mediaBackup actions', () => {
     expect(endMediaUpload()).toEqual(expectedAction)
   })
 
-  it('should create an action to success image upload', () => {
+  it('should create an action to success media upload', () => {
     const photo = { id: 1 }
-    const expectedAction = { type: IMAGE_UPLOAD_SUCCESS, id: photo.id }
-    expect(successImageUpload(photo)).toEqual(expectedAction)
+    const expectedAction = { type: MEDIA_UPLOAD_SUCCESS, id: photo.id }
+    expect(successMediaUpload(photo)).toEqual(expectedAction)
   })
 })

--- a/mobile/test/reducers/mediaBackup.spec.js
+++ b/mobile/test/reducers/mediaBackup.spec.js
@@ -1,5 +1,5 @@
 import reducer, { initialState } from '../../src/reducers/mediaBackup'
-import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, IMAGE_UPLOAD_SUCCESS } from '../../src/actions/mediaBackup'
+import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS } from '../../src/actions/mediaBackup'
 import { INIT_STATE } from '../../src/actions'
 
 describe('mediaBackup reducers', () => {
@@ -18,11 +18,11 @@ describe('mediaBackup reducers', () => {
     .toEqual({uploading: false})
   })
 
-  it('should handle IMAGE_UPLOAD_SUCCESS', () => {
-    expect(reducer({uploaded: []}, {type: IMAGE_UPLOAD_SUCCESS, id: 1}))
+  it('should handle MEDIA_UPLOAD_SUCCESS', () => {
+    expect(reducer({uploaded: []}, {type: MEDIA_UPLOAD_SUCCESS, id: 1}))
     .toEqual({uploaded: [1]})
 
-    expect(reducer({uploaded: [1]}, {type: IMAGE_UPLOAD_SUCCESS, id: 2}))
+    expect(reducer({uploaded: [1]}, {type: MEDIA_UPLOAD_SUCCESS, id: 2}))
     .toEqual({uploaded: [1, 2]})
   })
 

--- a/src/containers/Folder.jsx
+++ b/src/containers/Folder.jsx
@@ -1,3 +1,5 @@
+/* global __TARGET__ */
+
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
@@ -17,6 +19,7 @@ import Empty from '../components/Empty'
 import Oops from '../components/Oops'
 import FileListHeader from '../components/FileListHeader'
 import FileList from '../components/FileList'
+import UploadProgression from '../../mobile/src/containers/UploadProgression'
 
 import FilesSelectionBar from '../containers/FilesSelectionBar'
 import TrashSelectionBar from '../containers/TrashSelectionBar'
@@ -54,6 +57,7 @@ class Folder extends Component {
     return (
       <div role='contentinfo'>
         <Alerter />
+        {__TARGET__ === 'mobile' && <UploadProgression /> }
         {!isTrashContext && showSelection && <FilesSelectionBar />}
         {isTrashContext && showSelection && <TrashSelectionBar />}
         {showDeleteConfirmation && <DeleteConfirmation />}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,8 +83,7 @@
     "trash_file_success": "The selection has been moved to the Trash.",
     "folder_name": "The folder %{folderName} already exists, please choose a new name.",
     "folder_generic": "An error occurred, please try again.",
-    "folder_abort": "You need to add a name to your new folder if you would like to save it. Your information has not been saved.",
-    "media_upload": "Backing up %{upload_counter} of %{total_upload} photos"
+    "folder_abort": "You need to add a name to your new folder if you would like to save it. Your information has not been saved."
   },
   "mobile": {
     "onboarding": {
@@ -142,7 +141,8 @@
         "wifi": {
           "title": "Backup on WIFI only",
           "label": "If the option is enabled, your device will only backup photos when it's on WIFI in order to save your package."
-        }
+        },
+        "media_upload": "Backing up %{upload_counter} of %{total_upload} photos"
       },
       "support": {
         "title": "Support",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,7 +83,8 @@
     "trash_file_success": "The selection has been moved to the Trash.",
     "folder_name": "The folder %{folderName} already exists, please choose a new name.",
     "folder_generic": "An error occurred, please try again.",
-    "folder_abort": "You need to add a name to your new folder if you would like to save it. Your information has not been saved."
+    "folder_abort": "You need to add a name to your new folder if you would like to save it. Your information has not been saved.",
+    "media_upload": "Backing up %{upload_counter} of %{total_upload} photos"
   },
   "mobile": {
     "onboarding": {


### PR DESCRIPTION
We could use `Alerter` from [cozy-ui](https://github.com/cozy/cozy-ui) but it seems not correct for this kind of progression message (see @goldoraf and @gregorylegarec for more information).

So the `UploadProgression` component is the very same UI than an Alerter, but it did not have the same behavior, it is very simpler: if a message is display, it is shown, otherwise it is not.

Hope it fits the needs.

![vgdmi9t](https://cloud.githubusercontent.com/assets/701648/24114180/918ea9fa-0d9f-11e7-9aaa-c4de3b2a0342.png)
