### PR TITLE
Swipe to dismiss the FAM

### DIFF
--- a/src/containers/FileActionMenu.jsx
+++ b/src/containers/FileActionMenu.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames'
 import { translate } from '../lib/I18n'
 import { Item } from 'react-bosonic/lib/Menu'
 import withGestures from '../lib/withGestures'
+import Hammer from 'hammerjs'
 
 import { splitFilename, getClassFromMime } from '../components/File'
 import { getActionableFiles } from '../reducers'
@@ -92,69 +93,70 @@ const Backdrop = withGestures(
 )(() => <div className={styles['fil-actionmenu-backdrop']} />)
 
 class FileActionMenu extends Component {
+  componentDidMount () {
+    this.gesturesHandler = new Hammer.Manager(this.fam, {
+      recognizers: [[Hammer.Pan, { direction: Hammer.DIRECTION_VERTICAL }]]
+    })
+
+    this.actionMenuNode = this.actionMenu.getDOMNode()
+
+    this.onDismissHandler = this.onDismiss.bind(this)
+
+    // to be completely accurate, `maximumGestureDelta` should be the difference between the top of the menu and the bottom of the page; but using the height is much easier to compute and accurate enough.
+    const maximumGestureDistance = this.actionMenuNode.getBoundingClientRect().height
+    const minimumCloseDistance = 0.6 // between 0 and 1, how far down the gesture must be to be considered complete upon release
+    const minimumCloseVelocity = 0.6 // a gesture faster than this will dismiss the menu, regardless of distance traveled
+
+    this.gesturesHandler.on('panstart', e => {
+      // disable css transitions during the gesture
+      this.actionMenuNode.classList.remove(styles['with-transition'])
+    })
+    this.gesturesHandler.on('pan', e => {
+      this.applyTransformation(e.deltaY / maximumGestureDistance)
+    })
+    this.gesturesHandler.on('panend', e => {
+      // re enable css transitions
+      this.actionMenuNode.classList.add(styles['with-transition'])
+      // dismiss the menu if the swipe pan was bigger than the treshold, or if it was a fast, downward gesture
+      let shouldDismiss = e.deltaY / maximumGestureDistance >= minimumCloseDistance ||
+                          (e.deltaY > 0 && e.velocity >= minimumCloseVelocity)
+
+      if (shouldDismiss) {
+        this.applyTransformation(1)
+        this.actionMenuNode.addEventListener('transitionend', this.onDismissHandler, false)
+      } else {
+        this.applyTransformation(0)
+      }
+    })
+  }
+
+  componentWillUnmount () {
+    this.gesturesHandler.destroy()
+  }
+
+  // applies a css trasnform to the element, based on the progress of the gesture
+  applyTransformation (progress) {
+    // wrap the progress between 0 and 1
+    progress = Math.min(1, Math.max(0, progress))
+    this.actionMenuNode.style.transform = 'translateY(' + (progress * 100) + '%)'
+  }
+
+  onDismiss () {
+    this.props.onClose()
+    // reset the menu
+    this.applyTransformation(0)
+    this.actionMenuNode.removeEventListener('transitionend', this.onDismissHandler)
+  }
+
   render (props) {
     return (
-      <div className={styles['fil-actionmenu-wrapper']}>
+      <div className={styles['fil-actionmenu-wrapper']} ref={fam => { this.fam = fam }}>
         <Backdrop {...props} />
         <ActionMenu {...props} ref={actionMenu => { this.actionMenu = actionMenu }} />
       </div>
     )
   }
 }
-
-let FileActionMenuWithGestures = withGestures(
-  function (ownProps) { // not an arrow function because we want to keep the context
-    let actionMenuNode = this.actionMenu.getDOMNode()
-
-    // to be completely accurate, `maximumGestureDelta` should be the difference between the top of the menu and the bottom of the page; but using the height is much easier to compute and accurate enough.
-    const maximumGestureDistance = actionMenuNode.getBoundingClientRect().height
-    const minimumCloseDistance = 0.6 // between 0 and 1, how far down the gesture must be to be considered complete upon release
-    const minimumCloseVelocity = 0.6 // a gesture faster than this will dismiss the menu, regardless of distance traveled
-
-    // applies a css trasnform to the element, based on the progress of the gesture
-    const applyTransformation = progress => {
-      // wrap the progress between 0 and 1
-      progress = Math.min(1, Math.max(0, progress))
-      actionMenuNode.style.transform = 'translateY(' + (progress * 100) + '%)'
-    }
-
-    // called to dismiss the menu, after a complete gesture and the css transition
-    const onDismiss = () => {
-      ownProps.onClose()
-      // reset the menu
-      applyTransformation(0)
-      actionMenuNode.removeEventListener('transitionend', onDismiss)
-    }
-
-    // declare the actual gesture callbacks
-    return {
-      panStart: e => {
-        // disable css transitions during the gesture
-        actionMenuNode.classList.remove(styles['with-transition'])
-      },
-      panDown: e => {
-        applyTransformation(e.deltaY / maximumGestureDistance)
-      },
-      panUp: e => {
-        applyTransformation(e.deltaY / maximumGestureDistance)
-      },
-      panEnd: e => {
-        // re enable css transitions
-        actionMenuNode.classList.add(styles['with-transition'])
-        // dismiss the menu if the swipe pan was bigger than the treshold, or if it was a fast, downward gesture
-        let shouldDismiss = e.deltaY / maximumGestureDistance >= minimumCloseDistance ||
-                            (e.deltaY > 0 && e.velocity >= minimumCloseVelocity)
-
-        if (shouldDismiss) {
-          applyTransformation(1)
-          actionMenuNode.addEventListener('transitionend', onDismiss, false)
-        } else {
-          applyTransformation(0)
-        }
-      }
-    }
-  }
-)(FileActionMenu)
 
 const mapStateToProps = (state, ownProps) => ({
   files: getActionableFiles(state),
@@ -199,4 +201,4 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(FileActionMenuWithGestures)
+)(FileActionMenu)

--- a/src/lib/withGestures.jsx
+++ b/src/lib/withGestures.jsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom'
 import Hammer from 'hammerjs'
 
 const shouldListenToSwipe = handlers => Object.keys(handlers).find(h => /^swipe/.test(h)) !== undefined
-const shouldListenToPan = handlers => Object.keys(handlers).find(h => /^pan/.test(h)) !== undefined
 const shouldListenToTap = handlers => Object.keys(handlers).find(h => /^tap/.test(h)) !== undefined
 
 const GHOST_CLICK_DELAY = 350
@@ -14,16 +13,11 @@ const withGestures = (eventHandlers) => {
       componentDidMount () {
         const node = ReactDOM.findDOMNode(this)
         this.hammer = new Hammer.Manager(node, {
-          recognizers: [[Hammer.Tap], [Hammer.Swipe, { direction: Hammer.DIRECTION_ALL }], [Hammer.Pan, { direction: Hammer.DIRECTION_ALL }]]
+          recognizers: [[Hammer.Tap], [Hammer.Swipe, { direction: Hammer.DIRECTION_ALL }]]
         })
-        this.handlers = eventHandlers.call(this.wrappedComponentInstance, this.props)
+        this.handlers = eventHandlers(this.props)
         if (shouldListenToSwipe(this.handlers)) {
           this.hammer.on('swipe', e => this.onSwipe(e))
-        }
-        if (shouldListenToPan(this.handlers)) {
-          this.hammer.on('pan', e => this.onPan(e))
-          this.hammer.on('panstart', e => this.onPan(e))
-          this.hammer.on('panend', e => this.onPan(e))
         }
         if (shouldListenToTap(this.handlers)) {
           // when listening for taps, we need to debounce the ghost click that happens right afterwards
@@ -65,26 +59,13 @@ const withGestures = (eventHandlers) => {
         if (e.direction === Hammer.DIRECTION_DOWN && this.handlers.swipeDown) this.handlers.swipeDown(e)
       }
 
-      onPan (e) {
-        if (e.type === 'pan') {
-          if (e.direction === Hammer.DIRECTION_LEFT && this.handlers.panLeft) this.handlers.panLeft(e)
-          if (e.direction === Hammer.DIRECTION_RIGHT && this.handlers.panRight) this.handlers.panRight(e)
-          if (e.direction === Hammer.DIRECTION_UP && this.handlers.panUp) this.handlers.panUp(e)
-          if (e.direction === Hammer.DIRECTION_DOWN && this.handlers.panDown) this.handlers.panDown(e)
-        } else if (e.type === 'panstart' && this.handlers.panStart) {
-          this.handlers.panStart(e)
-        } else if (e.type === 'panend' && this.handlers.panEnd) {
-          this.handlers.panEnd(e)
-        }
-      }
-
       onTap (e) {
         this.handlers.tap(e)
       }
 
       render () {
         return (
-          <WrappedComponent {...this.props} ref={wrapped => { this.wrappedComponentInstance = wrapped }} />
+          <WrappedComponent {...this.props} />
         )
       }
     }

--- a/src/lib/withGestures.jsx
+++ b/src/lib/withGestures.jsx
@@ -66,16 +66,14 @@ const withGestures = (eventHandlers) => {
       }
 
       onPan (e) {
-        if (e.type === 'pan'){
+        if (e.type === 'pan') {
           if (e.direction === Hammer.DIRECTION_LEFT && this.handlers.panLeft) this.handlers.panLeft(e)
           if (e.direction === Hammer.DIRECTION_RIGHT && this.handlers.panRight) this.handlers.panRight(e)
           if (e.direction === Hammer.DIRECTION_UP && this.handlers.panUp) this.handlers.panUp(e)
           if (e.direction === Hammer.DIRECTION_DOWN && this.handlers.panDown) this.handlers.panDown(e)
-        }
-        else if (e.type === 'panstart' && this.handlers.panStart) {
+        } else if (e.type === 'panstart' && this.handlers.panStart) {
           this.handlers.panStart(e)
-        }
-        else if (e.type === 'panend' && this.handlers.panEnd) {
+        } else if (e.type === 'panend' && this.handlers.panEnd) {
           this.handlers.panEnd(e)
         }
       }
@@ -86,7 +84,7 @@ const withGestures = (eventHandlers) => {
 
       render () {
         return (
-          <WrappedComponent {...this.props} ref={wrapped => this.wrappedComponentInstance = wrapped} />
+          <WrappedComponent {...this.props} ref={wrapped => { this.wrappedComponentInstance = wrapped }} />
         )
       }
     }

--- a/src/lib/withGestures.jsx
+++ b/src/lib/withGestures.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import Hammer from 'hammerjs'
 
 const shouldListenToSwipe = handlers => Object.keys(handlers).find(h => /^swipe/.test(h)) !== undefined
+const shouldListenToPan = handlers => Object.keys(handlers).find(h => /^pan/.test(h)) !== undefined
 const shouldListenToTap = handlers => Object.keys(handlers).find(h => /^tap/.test(h)) !== undefined
 
 const GHOST_CLICK_DELAY = 350
@@ -13,11 +14,16 @@ const withGestures = (eventHandlers) => {
       componentDidMount () {
         const node = ReactDOM.findDOMNode(this)
         this.hammer = new Hammer.Manager(node, {
-          recognizers: [[Hammer.Tap], [Hammer.Swipe, { direction: Hammer.DIRECTION_ALL }]]
+          recognizers: [[Hammer.Tap], [Hammer.Swipe, { direction: Hammer.DIRECTION_ALL }], [Hammer.Pan, { direction: Hammer.DIRECTION_ALL }]]
         })
-        this.handlers = eventHandlers(this.props)
+        this.handlers = eventHandlers.call(this.wrappedComponentInstance, this.props)
         if (shouldListenToSwipe(this.handlers)) {
           this.hammer.on('swipe', e => this.onSwipe(e))
+        }
+        if (shouldListenToPan(this.handlers)) {
+          this.hammer.on('pan', e => this.onPan(e))
+          this.hammer.on('panstart', e => this.onPan(e))
+          this.hammer.on('panend', e => this.onPan(e))
         }
         if (shouldListenToTap(this.handlers)) {
           // when listening for taps, we need to debounce the ghost click that happens right afterwards
@@ -59,13 +65,28 @@ const withGestures = (eventHandlers) => {
         if (e.direction === Hammer.DIRECTION_DOWN && this.handlers.swipeDown) this.handlers.swipeDown(e)
       }
 
+      onPan (e) {
+        if (e.type === 'pan'){
+          if (e.direction === Hammer.DIRECTION_LEFT && this.handlers.panLeft) this.handlers.panLeft(e)
+          if (e.direction === Hammer.DIRECTION_RIGHT && this.handlers.panRight) this.handlers.panRight(e)
+          if (e.direction === Hammer.DIRECTION_UP && this.handlers.panUp) this.handlers.panUp(e)
+          if (e.direction === Hammer.DIRECTION_DOWN && this.handlers.panDown) this.handlers.panDown(e)
+        }
+        else if (e.type === 'panstart' && this.handlers.panStart) {
+          this.handlers.panStart(e)
+        }
+        else if (e.type === 'panend' && this.handlers.panEnd) {
+          this.handlers.panEnd(e)
+        }
+      }
+
       onTap (e) {
         this.handlers.tap(e)
       }
 
       render () {
         return (
-          <WrappedComponent {...this.props} />
+          <WrappedComponent {...this.props} ref={wrapped => this.wrappedComponentInstance = wrapped} />
         )
       }
     }

--- a/src/styles/actionmenu.styl
+++ b/src/styles/actionmenu.styl
@@ -19,6 +19,9 @@
     margin         0 em(8px)
     padding-bottom em(5px)
 
+    &.with-transition
+        transition transform .1s ease-out
+
     hr
         margin-top 0
 


### PR DESCRIPTION
The whole FileActionMenu can now be swipped, and the menu follows the gesture.

![swipe](https://thumbs.gfycat.com/BronzeUnitedKodiakbear-size_restricted.gif)