### PR TITLE
Chore/upgrade ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "classnames": "^2.2.0",
     "cozy-bar": "3.0.0-beta11",
     "cozy-client-js": "^0.1.8",
-    "cozy-ui": "3.0.0-beta15",
+    "cozy-ui": "3.0.0-beta16",
     "date-fns": "^1.22.0",
     "filesize": "^3.3.0",
     "hammerjs": "^2.0.8",

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -7,4 +7,4 @@
     top-padded(30px)
 
     @media (max-width: (768/basefont)rem)
-        top-padded(10px)
+        padding 0

--- a/src/styles/toolbar.styl
+++ b/src/styles/toolbar.styl
@@ -72,7 +72,7 @@ b-item
 @media (max-width: (768/basefont)rem)
     .fil-toolbar-files
     .fil-toolbar-trash
-        position absolute
+        position fixed
         top      0
         right    0
         z-index  $nav-index

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,9 +1423,9 @@ cozy-client-js@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.1.8.tgz#4d2edbf88d06b415ef7180016bb01275ffeb3957"
 
-cozy-ui@3.0.0-beta15:
-  version "3.0.0-beta15"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta15.tgz#3b2a7e0ba3ed3a00cb87e46f2df0505d0a3fb24e"
+cozy-ui@3.0.0-beta16:
+  version "3.0.0-beta16"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-3.0.0-beta16.tgz#00a56ea532aea6663b7e11a0c650b456bea4a803"
   dependencies:
     classnames "^2.2.5"
     md5 "^2.2.0"


### PR DESCRIPTION
Upgraded Cozy-UI to beta16 and micro-fixes because of this.
The toolbar wasn't positioned at the right place, in fact it shouldn't have been before but adding `position: relative` to the sibling of its parent made it explode.