### PR TITLE
[fix] Dismiss menu when already down

### DIFF
--- a/src/containers/FileActionMenu.jsx
+++ b/src/containers/FileActionMenu.jsx
@@ -100,19 +100,23 @@ class FileActionMenu extends Component {
 
     this.actionMenuNode = this.actionMenu.getDOMNode()
 
-    this.onDismissHandler = this.onDismiss.bind(this)
+    this.dismissHandler = this.dismiss.bind(this)
 
     // to be completely accurate, `maximumGestureDelta` should be the difference between the top of the menu and the bottom of the page; but using the height is much easier to compute and accurate enough.
     const maximumGestureDistance = this.actionMenuNode.getBoundingClientRect().height
     const minimumCloseDistance = 0.6 // between 0 and 1, how far down the gesture must be to be considered complete upon release
     const minimumCloseVelocity = 0.6 // a gesture faster than this will dismiss the menu, regardless of distance traveled
 
+    let currentGestureProgress = null
+
     this.gesturesHandler.on('panstart', e => {
       // disable css transitions during the gesture
       this.actionMenuNode.classList.remove(styles['with-transition'])
+      currentGestureProgress = 0
     })
     this.gesturesHandler.on('pan', e => {
-      this.applyTransformation(e.deltaY / maximumGestureDistance)
+      currentGestureProgress = e.deltaY / maximumGestureDistance
+      this.applyTransformation(currentGestureProgress)
     })
     this.gesturesHandler.on('panend', e => {
       // re enable css transitions
@@ -122,8 +126,14 @@ class FileActionMenu extends Component {
                           (e.deltaY > 0 && e.velocity >= minimumCloseVelocity)
 
       if (shouldDismiss) {
-        this.applyTransformation(1)
-        this.actionMenuNode.addEventListener('transitionend', this.onDismissHandler, false)
+        if (currentGestureProgress >= 1) {
+          // the menu was already hidden, we can close it right away
+          this.dismissHandler()
+        } else {
+          // we need to transition the menu to the bottom before dismissing it
+          this.actionMenuNode.addEventListener('transitionend', this.dismissHandler, false)
+          this.applyTransformation(1)
+        }
       } else {
         this.applyTransformation(0)
       }
@@ -141,11 +151,11 @@ class FileActionMenu extends Component {
     this.actionMenuNode.style.transform = 'translateY(' + (progress * 100) + '%)'
   }
 
-  onDismiss () {
+  dismiss () {
     this.props.onClose()
-    // reset the menu
+    // remove the event handler so subsequent transitions don't trigger dismissals
+    this.actionMenuNode.removeEventListener('transitionend', this.dismissHandler)
     this.applyTransformation(0)
-    this.actionMenuNode.removeEventListener('transitionend', this.onDismissHandler)
   }
 
   render (props) {


### PR DESCRIPTION
Handles the case where the gesture ends when the menu is already past the bottom of the screen, and no `transitionend` event is fired.