### PR TITLE
fix: update cozy-ui's modal usage

### DIFF
--- a/mobile/src/components/Settings.jsx
+++ b/mobile/src/components/Settings.jsx
@@ -46,11 +46,11 @@ export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages,
       {displayUnlinkConfirmation && <Modal
         title={t('mobile.settings.unlink.confirmation.title')}
         description={t('mobile.settings.unlink.confirmation.description')}
-        cancelText={t('mobile.settings.unlink.confirmation.cancel')}
-        cancelAction={hideUnlinkConfirmation}
-        validateType='danger'
-        validateText={t('mobile.settings.unlink.confirmation.unlink')}
-        validateAction={() => unlink(client)}
+        secondaryText={t('mobile.settings.unlink.confirmation.cancel')}
+        secondaryAction={hideUnlinkConfirmation}
+        primaryType='danger'
+        primaryText={t('mobile.settings.unlink.confirmation.unlink')}
+        primaryAction={() => unlink(client)}
       />}
 
     </div>

--- a/mobile/src/containers/RevokableWrapper.jsx
+++ b/mobile/src/containers/RevokableWrapper.jsx
@@ -32,10 +32,10 @@ class RevokableWrapper extends Component {
           <Modal
             title={t('mobile.revoked.title')}
             description={t('mobile.revoked.description')}
-            cancelText={t('mobile.revoked.logout')}
-            cancelAction={() => { this.logout() }}
-            validateText={t('mobile.revoked.loginagain')}
-            validateAction={() => { this.loginagain() }}
+            secondaryText={t('mobile.revoked.logout')}
+            secondaryAction={() => { this.logout() }}
+            primaryText={t('mobile.revoked.loginagain')}
+            primaryAction={() => { this.loginagain() }}
             withCross={false}
           />
           {children}

--- a/src/containers/DeleteConfirmation.jsx
+++ b/src/containers/DeleteConfirmation.jsx
@@ -19,11 +19,11 @@ const DeleteConfirmation = ({ t, files, onConfirm, onDismiss, dropSelection }) =
   return (<Modal
     title={t('deleteconfirmation.title', files.length)}
     description={deleteConfirmationTexts}
-    cancelText={t('deleteconfirmation.cancel')}
-    cancelAction={() => onDismiss(files, dropSelection)}
-    validateType='danger'
-    validateText={t('deleteconfirmation.delete')}
-    validateAction={() => onConfirm(files, dropSelection)}
+    secondaryText={t('deleteconfirmation.cancel')}
+    secondaryAction={() => onDismiss(files, dropSelection)}
+    primaryType='danger'
+    primaryText={t('deleteconfirmation.delete')}
+    primaryAction={() => onConfirm(files, dropSelection)}
    />)
 }
 


### PR DESCRIPTION
As `cancel...` and `validate...` are deprecated.

@y-lohse or @CPatchane could you validate the code change as it impacts `src/containers/DeleteConfirmation.jsx`?

Only one approval is needed 😉 