### PR TITLE
[fix] Handle undefined contents relation

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -67,7 +67,7 @@ export const openFolder = (folderId, context = FILES_CONTEXT) => {
       context,
       folder: Object.assign(extractFileAttributes(folder), {
         parent: extractFileAttributes(parent)}),
-      files: folder.relations('contents').map(
+      files: (folder.relations('contents') || []).map(
         c => extractFileAttributes(c)
       )
     })


### PR DESCRIPTION
The result of `folder.relations('contents')` is not always an array, it [can be `null`, `undefined`, and more](https://github.com/cozy/cozy-client-js/blob/e6657ce1c5b472757c5e822700b3b5cbb1e2a9f5/src/jsonapi.js#L16).