### PR TITLE
feat: add debug tool in settings page :microscope:

### DIFF
--- a/mobile/src/components/Settings.jsx
+++ b/mobile/src/components/Settings.jsx
@@ -1,6 +1,9 @@
+/* globals __DEVMODE__ */
+
 import React from 'react'
 import Modal from 'cozy-ui/react/Modal'
 import styles from '../styles/settings'
+import DebugTools from '../containers/DebugTools'
 import { translate } from '../../../src/lib/I18n'
 
 const SubCategory = ({ id, label, value, title }) => (
@@ -52,6 +55,14 @@ export const Settings = ({ t, version, serverUrl, backupImages, setBackupImages,
         primaryText={t('mobile.settings.unlink.confirmation.unlink')}
         primaryAction={() => unlink(client)}
       />}
+
+      {__DEVMODE__ &&
+        [
+          <hr />,
+          <h3>Debug Zone</h3>,
+          <DebugTools />
+        ]
+      }
 
     </div>
   </div>

--- a/mobile/src/containers/DebugTools.jsx
+++ b/mobile/src/containers/DebugTools.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { logException, logInfo } from '../lib/reporter'
+
+const Button = ({ onClick, children }) => (
+  <button onclick={onClick} className={'coz-btn coz-btn--regular'}>
+    {children}
+  </button>
+)
+
+class DebugTools extends React.Component {
+  sendSentryException () {
+    logException('a debug exception')
+  }
+  sendSentryMessage () {
+    logInfo('a debug message')
+  }
+
+  render () {
+    return (
+      <div>
+        <h4>Sentry</h4>
+        <Button onClick={() => this.sendSentryException()}>send exception</Button>
+        <Button onClick={() => this.sendSentryMessage()}>send message</Button>
+      </div>
+    )
+  }
+}
+
+export default DebugTools


### PR DESCRIPTION
This PR is a proposal to add a debug tool in settings page.
It is displayed only in `dev mode`  activable by webpack configuration manipulation.

#### Checklist

Before merging this PR, the following things must have been done:

- [ ] ~Faithful integration of the mockups at all screen sizes~
- [ ] ~Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)~
- [ ] ~Localized in english and french~
- [ ] ~All changes have test coverage~
- [ ] ~Updated README, if necessary~
