### PR TITLE
fix: shouldSendCallback uses the state :interrobang:

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -39,14 +39,16 @@ export const checkURL = url => dispatch => {
 // settings
 
 export const setAnalytics = analytics => (dispatch, getState) => {
-  if (analytics && getState().mobile) {
-    getState().mobile.settings.backupImages ? logInfo('settings: backup images is enabled') : logInfo('settings: backup images is disabled')
-  }
   dispatch({ type: SET_ANALYTICS, analytics })
+  const state = getState()
+  if (analytics && state.mobile) {
+    state.mobile.settings.backupImages ? logInfo('settings: backup images is enabled') : logInfo('settings: backup images is disabled')
+  }
 }
 
 export const setBackupImages = backupImages => (dispatch, getState) => {
-  if (getState().mobile && getState().mobile.settings.analytics) {
+  const state = getState()
+  if (state.mobile && state.mobile.settings.analytics) {
     backupImages ? logInfo('settings: backup images is enabled') : logInfo('settings: backup images is disabled')
   }
   backupImages ? startBackgroundService() : stopBackgroundService()


### PR DESCRIPTION
It may be a smell to let the `reporter` depends on the *redux state*.
See https://github.com/cozy/cozy-files-v3/blob/master/mobile/src/lib/reporter.js#L10

So in that particular case, the message was sent to sentry before the global state was set. So the message was not sent. Nice 🎉 !

#### Checklist

Before merging this PR, the following things must have been done:

- [ ] ~Faithful integration of the mockups at all screen sizes~
- [ ] ~Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)~
- [ ] ~Localized in english and french~
- [ ] All changes have test coverage
- [ ] ~Updated README, if necessary~
