### PR TITLE
feat: Add online view after subscribe 🏃

### DIFF
--- a/mobile/src/actions/index.js
+++ b/mobile/src/actions/index.js
@@ -1,8 +1,5 @@
 import { OPEN_FILE_E_OFFLINE, OPEN_FILE_E_NO_APP } from '../../../src/actions'
 
-export const INIT_STATE = 'INIT_STATE'
-export const initializeState = () => ({ type: INIT_STATE })
-
 export const OPEN_WITH_OFFLINE_ERROR = 'mobile.error.open_with.offline'
 export const OPEN_WITH_NO_APP_ERROR = 'mobile.error.open_with.noapp'
 export const createError = (type, msg) => ({type: type, alert: { message: msg, level: 'error' }})

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,6 +1,6 @@
 /* global cozy, __ALLOW_HTTP__ */
 
-import { initClient, startReplication } from '../lib/cozy-helper'
+import { initClient, startReplication as startPouchReplication } from '../lib/cozy-helper'
 import { setClient, setFirstReplication } from '../../../src/actions/settings'
 import { openFolder } from '../../../src/actions'
 import { onRegistered } from '../lib/registration'
@@ -87,15 +87,19 @@ export const registerDevice = () => async (dispatch, getState) => {
   initClient(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
   await cozy.client.authorize().then(({ client }) => {
     dispatch(setClient(client))
-
-    const firstReplication = getState().settings.firstReplication
-    const refreshFolder = () => { dispatch(openFolder(getState().folder.id)) }
-    const revokeClient = () => { dispatch(reduxRevokeClient()) }
-    const firstReplicationFinished = () => { dispatch(setFirstReplication(true)) }
-    startReplication(firstReplication, firstReplicationFinished, refreshFolder, revokeClient, dispatch, getState)
+    startReplication(dispatch, getState)
   }).catch(err => {
     dispatch(wrongAddressError())
     logException(err)
     throw err
   })
+}
+
+export const startReplication = (dispatch, getState) => {
+  const firstReplication = getState().settings.firstReplication
+  const refreshFolder = () => { dispatch(openFolder(getState().folder.id)) }
+  const revokeClient = () => { dispatch(reduxRevokeClient()) }
+  const firstReplicationFinished = () => { dispatch(setFirstReplication(true)) }
+
+  startPouchReplication(firstReplication, firstReplicationFinished, refreshFolder, revokeClient)
 }

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,6 +1,6 @@
 /* global cozy, __ALLOW_HTTP__ */
 
-import { initClient, startFirstReplication } from '../lib/cozy-helper'
+import { initClient, startReplication } from '../lib/cozy-helper'
 import { setClient } from '../../../src/actions/settings'
 import { onRegistered } from '../lib/registration'
 import { logException, logInfo } from '../lib/reporter'
@@ -85,7 +85,7 @@ export const registerDevice = () => async (dispatch, getState) => {
   initClient(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
   await cozy.client.authorize().then(({ client }) => {
     dispatch(setClient(client))
-    startFirstReplication(dispatch, getState)
+    startReplication(dispatch, getState)
   }).catch(err => {
     dispatch(wrongAddressError())
     logException(err)

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,6 +1,7 @@
 /* global cozy, __ALLOW_HTTP__ */
 
-import { initClient, startReplication as startPouchReplication } from '../lib/cozy-helper'
+import { initClient } from '../lib/cozy-helper'
+import { startReplication as startPouchReplication } from '../lib/replication'
 import { setClient, setFirstReplication } from '../../../src/actions/settings'
 import { openFolder } from '../../../src/actions'
 import { onRegistered } from '../lib/registration'

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -1,7 +1,7 @@
 /* global cozy, __ALLOW_HTTP__ */
 
 import { initClient, startFirstReplication } from '../lib/cozy-helper'
-import { setOffline } from '../../../src/actions'
+import { setClient } from '../../../src/actions/settings'
 import { onRegistered } from '../lib/registration'
 import { logException, logInfo } from '../lib/reporter'
 import { pingOnceADay } from './timestamp'
@@ -11,10 +11,7 @@ export const SET_URL = 'SET_URL'
 export const BACKUP_IMAGES = 'BACKUP_IMAGES'
 export const WIFI_ONLY = 'WIFI_ONLY'
 export const ERROR = 'ERROR'
-export const SET_CLIENT = 'SET_CLIENT'
 export const SET_ANALYTICS = 'SET_ANALYTICS'
-
-import { unrevokeClient } from './authorization'
 
 // url
 
@@ -87,9 +84,7 @@ export const registerDevice = () => async (dispatch, getState) => {
   dispatch(checkURL(getState().mobile.settings.serverUrl))
   initClient(getState().mobile.settings.serverUrl, onRegister(dispatch), device)
   await cozy.client.authorize().then(({ client }) => {
-    dispatch(unrevokeClient())
     dispatch(setClient(client))
-    dispatch(setOffline(true))
     startFirstReplication(dispatch, getState)
   }).catch(err => {
     dispatch(wrongAddressError())
@@ -97,5 +92,3 @@ export const registerDevice = () => async (dispatch, getState) => {
     throw err
   })
 }
-
-export const setClient = client => ({ type: SET_CLIENT, client })

--- a/mobile/src/actions/unlink.js
+++ b/mobile/src/actions/unlink.js
@@ -1,6 +1,6 @@
 /* global cozy */
 
-import { initializeState } from '.'
+import { initializeState } from '../../../src/actions'
 import { resetClient } from '../lib/cozy-helper'
 
 // constants

--- a/mobile/src/actions/unlink.js
+++ b/mobile/src/actions/unlink.js
@@ -1,6 +1,6 @@
 /* global cozy */
 
-import { initializeState } from '../../../src/actions'
+import { initializeState } from '../../../src/actions/settings'
 import { resetClient } from '../lib/cozy-helper'
 
 // constants

--- a/mobile/src/containers/DebugTools.jsx
+++ b/mobile/src/containers/DebugTools.jsx
@@ -1,5 +1,7 @@
-import React from 'react'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
 import { logException, logInfo } from '../lib/reporter'
+import { setFirstReplication, setOffline } from '../../../src/actions'
 
 const Button = ({ onClick, children }) => (
   <button onclick={onClick} className={'coz-btn coz-btn--regular'}>
@@ -7,10 +9,17 @@ const Button = ({ onClick, children }) => (
   </button>
 )
 
-class DebugTools extends React.Component {
+const Checkbox = ({ onChange, value, title }) => (
+  <div>
+    {title} <input type='checkbox' checked={value} onChange={onChange} />
+  </div>
+)
+
+class DebugTools extends Component {
   sendSentryException () {
     logException('a debug exception')
   }
+
   sendSentryMessage () {
     logInfo('a debug message')
   }
@@ -21,9 +30,22 @@ class DebugTools extends React.Component {
         <h4>Sentry</h4>
         <Button onClick={() => this.sendSentryException()}>send exception</Button>
         <Button onClick={() => this.sendSentryMessage()}>send message</Button>
+        <h4>Offline</h4>
+        <Checkbox title='First Replication' value={this.props.firstReplication} onChange={this.props.setFirstReplication} />
+        <Checkbox title='Offline' value={this.props.offline} onChange={this.props.setOffline} />
       </div>
     )
   }
 }
 
-export default DebugTools
+const mapDispatchToProps = (dispatch) => ({
+  setFirstReplication: (e) => dispatch(setFirstReplication(e.target.checked)),
+  setOffline: (e) => dispatch(setOffline(e.target.checked))
+})
+
+const mapStateToProps = (state) => ({
+  firstReplication: state.settings.firstReplication,
+  offline: state.settings.offline
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DebugTools)

--- a/mobile/src/containers/Settings.jsx
+++ b/mobile/src/containers/Settings.jsx
@@ -12,7 +12,7 @@ const mapStateToProps = (state, ownProps) => ({
   backupImages: state.mobile.settings.backupImages,
   analytics: state.mobile.settings.analytics,
   displayUnlinkConfirmation: state.mobile.ui.displayUnlinkConfirmation,
-  client: state.mobile.settings.client,
+  client: state.settings.client,
   wifiOnly: state.mobile.settings.wifiOnly,
   backupAllowed: backupAllowed(state.mobile.settings.wifiOnly)
 })

--- a/mobile/src/lib/cozy-helper.js
+++ b/mobile/src/lib/cozy-helper.js
@@ -2,9 +2,6 @@
 
 import { LocalStorage as Storage } from 'cozy-client-js'
 
-import { openFolder, setFirstReplication } from '../../../src/actions'
-import { revokeClient } from '../actions/authorization'
-
 const clientRevokedMsg = 'Client has been revoked'
 const getStorage = () => new Storage()
 const getClientName = device => `Cozy Files Application on ${device} (${Math.random().toString(36).slice(2)})`
@@ -71,45 +68,5 @@ export function resetClient () {
   // reset cozy-client-js
   if (cozy.client._storage) {
     cozy.client._storage.clear()
-  }
-}
-
-export function refreshFolder (dispatch, getState) {
-  return result => {
-    if (result.docs_written !== 0) {
-      dispatch(openFolder(getState().folder.id))
-    }
-  }
-}
-
-export const startRepeatedReplication = (dispatch, getState) => {
-  const options = {
-    onError: onError(dispatch, getState),
-    onComplete: refreshFolder(dispatch, getState)
-  }
-  cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
-}
-
-export const startFirstReplication = (dispatch, getState) => {
-  const options = {
-    onError: onError(dispatch, getState),
-    onComplete: () => {
-      dispatch(setFirstReplication(true))
-      startRepeatedReplication(dispatch, getState)
-    }
-  }
-  cozy.client.offline.replicateFromCozy('io.cozy.files', options).then(() => {
-    console.log('End of Replication')
-  })
-}
-
-export const onError = (dispatch, getState) => (err) => {
-  if (err.message === clientRevokedMsg || err.error === 'code=400, message=Invalid JWT token') {
-    console.warn(`Your device is no more connected to your server: ${getState().mobile.settings.serverUrl}`)
-    dispatch(revokeClient())
-  } else if (err.message === 'ETIMEDOUT') {
-    console.log('timeout')
-  } else {
-    console.warn(err)
   }
 }

--- a/mobile/src/lib/replication.js
+++ b/mobile/src/lib/replication.js
@@ -1,0 +1,53 @@
+/* global cozy */
+import { revokeClient } from '../actions/authorization'
+import { clientRevokedMsg } from './cozy-helper'
+import { openFolder, setFirstReplication } from '../../../src/actions'
+
+export const startReplication = (dispatch, getState) => {
+  const firstReplicationIsFinished = getState().settings.firstReplication
+  if (firstReplicationIsFinished) {
+    startRepeatedReplication(dispatch, getState)
+  } else {
+    startFirstReplication(dispatch, getState)
+  }
+}
+
+const startRepeatedReplication = (dispatch, getState) => {
+  const options = {
+    onError: onError(dispatch, getState),
+    onComplete: refreshFolder(dispatch, getState)
+  }
+  cozy.client.offline.startRepeatedReplication('io.cozy.files', 15, options)
+}
+
+const startFirstReplication = (dispatch, getState) => {
+  const options = {
+    onError: onError(dispatch, getState),
+    onComplete: () => {
+      dispatch(setFirstReplication(true))
+      startRepeatedReplication(dispatch, getState)
+    }
+  }
+  cozy.client.offline.replicateFromCozy('io.cozy.files', options).then(() => {
+    console.log('End of Replication')
+  })
+}
+
+export function refreshFolder (dispatch, getState) {
+  return result => {
+    if (result.docs_written !== 0) {
+      dispatch(openFolder(getState().folder.id))
+    }
+  }
+}
+
+export const onError = (dispatch, getState) => (err) => {
+  if (err.message === clientRevokedMsg || err.error === 'code=400, message=Invalid JWT token') {
+    console.warn(`Your device is no more connected to your server: ${getState().mobile.settings.serverUrl}`)
+    dispatch(revokeClient())
+  } else if (err.message === 'ETIMEDOUT') {
+    console.log('timeout')
+  } else {
+    console.warn(err)
+  }
+}

--- a/mobile/src/lib/store.js
+++ b/mobile/src/lib/store.js
@@ -22,6 +22,7 @@ export const configureStore = (persistedState) => {
   )
 
   store.subscribe(() => saveState({
+    settings: store.getState().settings,
     mobile: {
       timestamp: store.getState().mobile.timestamp,
       settings: store.getState().mobile.settings,

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -24,7 +24,7 @@ const renderAppWithPersistedState = persistedState => {
 
   function requireSetup (nextState, replace, callback) {
     const state = store.getState()
-    const client = state.mobile.settings.client
+    const client = state.settings.client
     const isSetup = state.mobile.settings.authorized
     const isFirstReplicationFinished = state.settings.firstReplication
     if (isSetup) {

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -15,7 +15,8 @@ import { loadState } from './lib/localStorage'
 import { configureStore } from './lib/store'
 import { initService } from './lib/init'
 import { startBackgroundService, stopBackgroundService } from './lib/background'
-import { initBar, isClientRegistered, resetClient, startRepeatedReplication, startFirstReplication, onError } from './lib/cozy-helper'
+import { initBar, isClientRegistered, resetClient } from './lib/cozy-helper'
+import { startReplication, onError } from './lib/replication'
 import { pingOnceADay } from './actions/timestamp'
 
 const renderAppWithPersistedState = persistedState => {
@@ -26,15 +27,10 @@ const renderAppWithPersistedState = persistedState => {
     const state = store.getState()
     const client = state.settings.client
     const isSetup = state.mobile.settings.authorized
-    const isFirstReplicationFinished = state.settings.firstReplication
     if (isSetup) {
       isClientRegistered(client).then(clientIsRegistered => {
         if (clientIsRegistered) {
-          if (isFirstReplicationFinished) {
-            startRepeatedReplication(store.dispatch, store.getState)
-          } else {
-            startFirstReplication(store.dispatch, store.getState)
-          }
+          startReplication(store.dispatch, store.getState)
           initBar()
         } else {
           onError(store.dispatch, store.getState)({ message: 'Client has been revoked' })

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -16,11 +16,9 @@ import { configureStore } from './lib/store'
 import { initService } from './lib/init'
 import { startBackgroundService, stopBackgroundService } from './lib/background'
 import { initBar, isClientRegistered, resetClient } from './lib/cozy-helper'
-import { startReplication, onError } from './lib/replication'
+import { onError } from './lib/replication'
 import { pingOnceADay } from './actions/timestamp'
-import { openFolder } from '../../src/actions'
-import { revokeClient as reduxRevokeClient } from './actions/authorization'
-import { setFirstReplication } from '../../src/actions/settings'
+import { startReplication } from './actions/settings'
 
 const renderAppWithPersistedState = persistedState => {
   const store = configureStore(persistedState)
@@ -33,11 +31,7 @@ const renderAppWithPersistedState = persistedState => {
     if (isSetup) {
       isClientRegistered(client).then(clientIsRegistered => {
         if (clientIsRegistered) {
-          const firstReplication = store.getState().settings.firstReplication
-          const refreshFolder = () => { store.dispatch(openFolder(store.getState().folder.id)) }
-          const revokeClient = () => { store.dispatch(reduxRevokeClient()) }
-          const firstReplicationFinished = () => { store.dispatch(setFirstReplication(true)) }
-          startReplication(firstReplication, firstReplicationFinished, refreshFolder, revokeClient, store.dispatch, store.getState)
+          startReplication(store.dispatch, store.getState)
           initBar()
         } else {
           onError(store.dispatch)({ message: 'Client has been revoked' })

--- a/mobile/src/reducers/authorization.js
+++ b/mobile/src/reducers/authorization.js
@@ -1,3 +1,4 @@
+import { SET_CLIENT } from '../../../src/actions/settings'
 import { REVOKE, UNREVOKE } from '../actions/authorization'
 
 export const initialState = {
@@ -8,6 +9,8 @@ export const authorization = (state = initialState, action) => {
     case REVOKE:
       return { ...state, revoked: true }
     case UNREVOKE:
+      return { ...state, revoked: false }
+    case SET_CLIENT:
       return { ...state, revoked: false }
     default:
       return state

--- a/mobile/src/reducers/mediaBackup.js
+++ b/mobile/src/reducers/mediaBackup.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../actions'
+import { INIT_STATE } from '../../../src/actions'
 import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS, CURRENT_UPLOAD } from '../actions/mediaBackup'
 
 export const initialState = {

--- a/mobile/src/reducers/mediaBackup.js
+++ b/mobile/src/reducers/mediaBackup.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../../../src/actions'
+import { INIT_STATE } from '../../../src/actions/settings'
 import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS, CURRENT_UPLOAD } from '../actions/mediaBackup'
 
 export const initialState = {

--- a/mobile/src/reducers/settings.js
+++ b/mobile/src/reducers/settings.js
@@ -1,5 +1,5 @@
-import { INIT_STATE } from '../../../src/actions'
-import { SET_URL, ERROR, BACKUP_IMAGES, SET_CLIENT, SET_ANALYTICS, WIFI_ONLY } from '../actions/settings'
+import { INIT_STATE, SET_CLIENT } from '../../../src/actions/settings'
+import { SET_URL, ERROR, BACKUP_IMAGES, SET_ANALYTICS, WIFI_ONLY } from '../actions/settings'
 
 export const initialState = {
   serverUrl: '',
@@ -22,7 +22,7 @@ export const settings = (state = initialState, action) => {
     case INIT_STATE:
       return initialState
     case SET_CLIENT:
-      return { ...state, client: action.client, authorized: true }
+      return { ...state, authorized: true }
     case WIFI_ONLY:
       return { ...state, wifiOnly: action.wifiOnly }
     default:

--- a/mobile/src/reducers/settings.js
+++ b/mobile/src/reducers/settings.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../actions'
+import { INIT_STATE } from '../../../src/actions'
 import { SET_URL, ERROR, BACKUP_IMAGES, SET_CLIENT, SET_ANALYTICS, WIFI_ONLY } from '../actions/settings'
 
 export const initialState = {

--- a/mobile/src/reducers/ui.js
+++ b/mobile/src/reducers/ui.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../actions'
+import { INIT_STATE } from '../../../src/actions'
 import { SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION } from '../actions/unlink'
 
 export const initialState = {

--- a/mobile/src/reducers/ui.js
+++ b/mobile/src/reducers/ui.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../../../src/actions'
+import { INIT_STATE } from '../../../src/actions/settings'
 import { SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION } from '../actions/unlink'
 
 export const initialState = {

--- a/mobile/test/actions/settings.spec.js
+++ b/mobile/test/actions/settings.spec.js
@@ -2,12 +2,12 @@ import { mockStore } from '../../../test/helpers'
 import reducer from '../../src/reducers/settings'
 import {
   SET_URL, setUrl, checkURL,
-  SET_CLIENT, setClient,
   setBackupImages,
   setWifiOnly,
   setAnalytics,
   OnBoardingError, wrongAddressError, ERROR, wrongAddressErrorMsg
 } from '../../src/actions/settings'
+import { SET_CLIENT, setClient } from '../../../src/actions/settings'
 
 describe('backup images actions creators', () => {
   it('should enable backup images', () => {

--- a/mobile/test/actions/unlink.spec.js
+++ b/mobile/test/actions/unlink.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global cozy */
 
-import { INIT_STATE } from '../../../src/actions'
+import { INIT_STATE } from '../../../src/actions/settings'
 import {
   SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION,
   showUnlinkConfirmation, hideUnlinkConfirmation, unlink

--- a/mobile/test/actions/unlink.spec.js
+++ b/mobile/test/actions/unlink.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 /* global cozy */
 
-import { INIT_STATE } from '../../src/actions'
+import { INIT_STATE } from '../../../src/actions'
 import {
   SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION,
   showUnlinkConfirmation, hideUnlinkConfirmation, unlink

--- a/mobile/test/reducers/mediaBackup.spec.js
+++ b/mobile/test/reducers/mediaBackup.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/mediaBackup'
 import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS } from '../../src/actions/mediaBackup'
-import { INIT_STATE } from '../../src/actions'
+import { INIT_STATE } from '../../../src/actions'
 
 describe('mediaBackup reducers', () => {
   it('should return the initial state', () => {

--- a/mobile/test/reducers/mediaBackup.spec.js
+++ b/mobile/test/reducers/mediaBackup.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/mediaBackup'
 import { MEDIA_UPLOAD_START, MEDIA_UPLOAD_END, MEDIA_UPLOAD_SUCCESS } from '../../src/actions/mediaBackup'
-import { INIT_STATE } from '../../../src/actions'
+import { INIT_STATE } from '../../../src/actions/settings'
 
 describe('mediaBackup reducers', () => {
   it('should return the initial state', () => {

--- a/mobile/test/reducers/settings.spec.js
+++ b/mobile/test/reducers/settings.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/settings'
-import { INIT_STATE } from '../../../src/actions'
-import { SET_URL, ERROR, SET_CLIENT, SET_ANALYTICS } from '../../src/actions/settings'
+import { INIT_STATE } from '../../../src/actions/settings'
+import { SET_URL, ERROR, SET_ANALYTICS } from '../../src/actions/settings'
 
 describe('settings reducers', () => {
   it('should return the initial state', () => {
@@ -28,10 +28,5 @@ describe('settings reducers', () => {
   it('should handle INIT_STATE', () => {
     expect(reducer({serverUrl: 'serverUrl', backupImages: true, error: 'error'}, {type: INIT_STATE}))
     .toEqual(initialState)
-  })
-
-  it('should set a client into the state with "SET_CLIENT"', () => {
-    const client = { someParameter: 'Some Value' }
-    expect(reducer(undefined, { type: SET_CLIENT, client }).client).toEqual(client)
   })
 })

--- a/mobile/test/reducers/settings.spec.js
+++ b/mobile/test/reducers/settings.spec.js
@@ -1,5 +1,5 @@
 import reducer, { initialState } from '../../src/reducers/settings'
-import { INIT_STATE } from '../../src/actions'
+import { INIT_STATE } from '../../../src/actions'
 import { SET_URL, ERROR, SET_CLIENT, SET_ANALYTICS } from '../../src/actions/settings'
 
 describe('settings reducers', () => {

--- a/mobile/test/reducers/ui.spec.js
+++ b/mobile/test/reducers/ui.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/ui'
 import { SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION } from '../../src/actions/unlink'
-import { INIT_STATE } from '../../../src/actions'
+import { INIT_STATE } from '../../../src/actions/settings'
 
 describe('ui reducers', () => {
   it('should return the initial state', () => {

--- a/mobile/test/reducers/ui.spec.js
+++ b/mobile/test/reducers/ui.spec.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from '../../src/reducers/ui'
 import { SHOW_UNLINK_CONFIRMATION, HIDE_UNLINK_CONFIRMATION } from '../../src/actions/unlink'
-import { INIT_STATE } from '../../src/actions'
+import { INIT_STATE } from '../../../src/actions'
 
 describe('ui reducers', () => {
   it('should return the initial state', () => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -34,6 +34,8 @@ export const DOWNLOAD_FILE_E_OFFLINE = 'DOWNLOAD_FILE_E_OFFLINE'
 export const OPEN_FILE_WITH = 'OPEN_FILE_WITH'
 export const OPEN_FILE_E_OFFLINE = 'OPEN_FILE_E_OFFLINE'
 export const OPEN_FILE_E_NO_APP = 'OPEN_FILE_E_NO_APP'
+export const SET_OFFLINE = 'SET_OFFLINE'
+export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
 
 const extractFileAttributes = f => Object.assign({}, f.attributes, { id: f._id })
 const toServer = f => Object.assign({}, { attributes: f }, { _id: f.id })
@@ -313,6 +315,16 @@ export const actionMenuLoading = (menu) => ({
 export const actionMenuLoaded = (menu) => ({
   type: 'HIDE_SPINNER',
   menu
+})
+
+export const setOffline = (offline) => ({
+  type: SET_OFFLINE,
+  offline
+})
+
+export const setFirstReplication = (firstReplication) => ({
+  type: SET_FIRST_REPLICATION,
+  firstReplication
 })
 
 export const initializeState = () => ({ type: INIT_STATE })

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -55,12 +55,14 @@ export const openTrash = () => {
 }
 
 export const openFolder = (folderId) => {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     dispatch({ type: OPEN_FOLDER, folderId })
     try {
-      const folder = await cozy.client.files.statById(folderId)
+      const settings = getState().settings
+      const offline = settings.offline && settings.firstReplication
+      const folder = await cozy.client.files.statById(folderId, offline)
       const parentId = folder.attributes.dir_id
-      const parent = !!parentId && await cozy.client.files.statById(parentId)
+      const parent = !!parentId && await cozy.client.files.statById(parentId, offline)
       return dispatch({
         type: OPEN_FOLDER_SUCCESS,
         folder: Object.assign(extractFileAttributes(folder), {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,7 +4,6 @@ import { openWithOfflineError, openWithNoAppError } from '../../mobile/src/actio
 
 import { ROOT_DIR_ID, TRASH_DIR_ID } from '../constants/config.js'
 
-export const INIT_STATE = 'INIT_STATE'
 export const LOCATION_CHANGE = 'LOCATION_CHANGE'
 export const OPEN_FOLDER = 'OPEN_FOLDER'
 export const OPEN_FOLDER_SUCCESS = 'OPEN_FOLDER_SUCCESS'
@@ -34,8 +33,6 @@ export const DOWNLOAD_FILE_E_OFFLINE = 'DOWNLOAD_FILE_E_OFFLINE'
 export const OPEN_FILE_WITH = 'OPEN_FILE_WITH'
 export const OPEN_FILE_E_OFFLINE = 'OPEN_FILE_E_OFFLINE'
 export const OPEN_FILE_E_NO_APP = 'OPEN_FILE_E_NO_APP'
-export const SET_OFFLINE = 'SET_OFFLINE'
-export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
 
 const extractFileAttributes = f => Object.assign({}, f.attributes, { id: f._id })
 const toServer = f => Object.assign({}, { attributes: f }, { _id: f.id })
@@ -318,15 +315,3 @@ export const actionMenuLoaded = (menu) => ({
   type: 'HIDE_SPINNER',
   menu
 })
-
-export const setOffline = (offline) => ({
-  type: SET_OFFLINE,
-  offline
-})
-
-export const setFirstReplication = (firstReplication) => ({
-  type: SET_FIRST_REPLICATION,
-  firstReplication
-})
-
-export const initializeState = () => ({ type: INIT_STATE })

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,6 +4,7 @@ import { openWithOfflineError, openWithNoAppError } from '../../mobile/src/actio
 
 import { ROOT_DIR_ID, TRASH_DIR_ID } from '../constants/config.js'
 
+export const INIT_STATE = 'INIT_STATE'
 export const LOCATION_CHANGE = 'LOCATION_CHANGE'
 export const OPEN_FOLDER = 'OPEN_FOLDER'
 export const OPEN_FOLDER_SUCCESS = 'OPEN_FOLDER_SUCCESS'
@@ -313,3 +314,5 @@ export const actionMenuLoaded = (menu) => ({
   type: 'HIDE_SPINNER',
   menu
 })
+
+export const initializeState = () => ({ type: INIT_STATE })

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -1,0 +1,9 @@
+export const INIT_STATE = 'INIT_STATE'
+export const SET_CLIENT = 'SET_CLIENT'
+export const SET_OFFLINE = 'SET_OFFLINE'
+export const SET_FIRST_REPLICATION = 'SET_FIRST_REPLICATION'
+
+export const initializeState = () => ({ type: INIT_STATE })
+export const setClient = client => ({ type: SET_CLIENT, client })
+export const setOffline = offline => ({ type: SET_OFFLINE, offline })
+export const setFirstReplication = firstReplication => ({ type: SET_FIRST_REPLICATION, firstReplication })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,12 +2,14 @@ import { combineReducers } from 'redux'
 
 import view, { getFileById } from './view'
 import ui from './ui'
+import settings from './settings'
 
 import alerterReducer from 'cozy-ui/react/Alerter'
 
 export const reducers = {
   view,
   ui,
+  settings,
   alerts: alerterReducer
 }
 

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -1,0 +1,21 @@
+import { SET_OFFLINE, SET_FIRST_REPLICATION, INIT_STATE } from '../actions'
+
+export const initialState = {
+  offline: false,
+  firstReplication: false
+}
+
+export const settings = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_OFFLINE:
+      return { ...state, offline: action.offline }
+    case SET_FIRST_REPLICATION:
+      return { ...state, firstReplication: action.firstReplication }
+    case INIT_STATE:
+      return initialState
+    default:
+      return state
+  }
+}
+
+export default settings

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -1,4 +1,4 @@
-import { SET_OFFLINE, SET_FIRST_REPLICATION, INIT_STATE } from '../actions'
+import { SET_CLIENT, SET_OFFLINE, SET_FIRST_REPLICATION, INIT_STATE } from '../actions/settings'
 
 export const initialState = {
   offline: false,
@@ -7,6 +7,8 @@ export const initialState = {
 
 export const settings = (state = initialState, action) => {
   switch (action.type) {
+    case SET_CLIENT:
+      return { ...state, offline: true, client: action.client }
     case SET_OFFLINE:
       return { ...state, offline: action.offline }
     case SET_FIRST_REPLICATION:


### PR DESCRIPTION
Now after an user is registered, he can browse directly in its folders

This feature adds 2 flags:
- offline : on browser is false, on mobile is true after client is defined
- firstReplication : after client is registered, a replication is launched. At the end of this replication `firstReplication` is set to true. Now we can display offline folder.
