### PR TITLE
Kill two :bird: with one stone

### DIFF
--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -38,11 +38,12 @@ export const checkURL = url => dispatch => {
 
 // settings
 
-export const setAnalytics = analytics => (dispatch, getState) => {
+export const setAnalytics = (analytics, source = 'settings') => (dispatch, getState) => {
   dispatch({ type: SET_ANALYTICS, analytics })
   const state = getState()
   if (analytics && state.mobile) {
-    state.mobile.settings.backupImages ? logInfo('settings: backup images is enabled') : logInfo('settings: backup images is disabled')
+    const value = state.mobile.settings.backupImages
+    logInfo(`${source}: backup images is ${value ? 'enabled' : 'disabled'}`)
   }
 }
 

--- a/mobile/src/actions/settings.js
+++ b/mobile/src/actions/settings.js
@@ -3,6 +3,7 @@
 import { initClient, refreshFolder, onError } from '../lib/cozy-helper'
 import { onRegistered } from '../lib/registration'
 import { logException, logInfo } from '../lib/reporter'
+import { pingOnceADay } from './timestamp'
 import { startBackgroundService, stopBackgroundService } from '../lib/background'
 
 export const SET_URL = 'SET_URL'
@@ -44,6 +45,7 @@ export const setAnalytics = (analytics, source = 'settings') => (dispatch, getSt
   if (analytics && state.mobile) {
     const value = state.mobile.settings.backupImages
     logInfo(`${source}: backup images is ${value ? 'enabled' : 'disabled'}`)
+    dispatch(pingOnceADay(state.mobile.timestamp, analytics))
   }
 }
 

--- a/mobile/src/actions/timestamp.js
+++ b/mobile/src/actions/timestamp.js
@@ -2,15 +2,13 @@ import { pingOnceADay as pingOnceADayReporter } from '../lib/reporter'
 
 export const SET_TIMESTAMP = 'SET_TIMESTAMP'
 
-export const pingOnceADay = (timestamp = new Date().getTime()) => (dispatch, getState) => {
-  if (getState().mobile.settings.analytics) {
-    const previousDate = new Date(timestamp)
-    if (!isToday(previousDate)) {
+export const pingOnceADay = (timestamp, analytics = false) => dispatch => {
+  if (analytics) {
+    if (!timestamp || !isToday(new Date(timestamp))) {
       pingOnceADayReporter()
       return dispatch({ type: SET_TIMESTAMP, timestamp: new Date().getTime() })
     }
   }
-  return dispatch({ type: SET_TIMESTAMP, timestamp })
 }
 
 function isToday (date) {

--- a/mobile/src/containers/onboarding/Analytics.jsx
+++ b/mobile/src/containers/onboarding/Analytics.jsx
@@ -10,7 +10,7 @@ export const Analytics = ({ onActivate, onSkip }) =>
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
   onActivate: () => {
-    dispatch(setAnalytics(true))
+    dispatch(setAnalytics(true, 'onboarbing'))
     ownProps.nextStep()
   },
   onSkip: () => {

--- a/mobile/src/main.jsx
+++ b/mobile/src/main.jsx
@@ -51,12 +51,21 @@ const renderAppWithPersistedState = persistedState => {
     }
   }
 
+  function pingOnceADayWithState () {
+    const state = store.getState()
+    if (state.mobile) {
+      const timestamp = state.mobile.timestamp
+      const analytics = state.mobile.settings.analytics
+      store.dispatch(pingOnceADay(timestamp, analytics))
+    }
+  }
+
   document.addEventListener('resume', () => {
-    store.dispatch(pingOnceADay(store.getState().mobile.timestamp))
+    pingOnceADayWithState()
   })
 
   document.addEventListener('deviceready', () => {
-    store.dispatch(pingOnceADay(store.getState().mobile.timestamp))
+    pingOnceADayWithState()
     if (store.getState().mobile.settings.backupImages) {
       startBackgroundService()
     } else {

--- a/mobile/src/reducers/timestamp.js
+++ b/mobile/src/reducers/timestamp.js
@@ -1,6 +1,6 @@
 import { SET_TIMESTAMP } from '../actions/timestamp'
 
-export function timestamp (state = Date.now(), action) {
+export function timestamp (state = null, action) {
   switch (action.type) {
     case SET_TIMESTAMP:
       return action.timestamp


### PR DESCRIPTION
- logInfo is launched when user change the backup image settings.
Now we know if he set the value in the onboarding or later in
the settings page.
- pingOnceADay was not triggered on fist launch as we initialized
the timestamp state with the current date before checking if
the timestamp is today or not.